### PR TITLE
ci(release): Publish to GitHub releases too

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -15,3 +15,4 @@ targets:
     target: getsentry/chartcuterie
   - name: npm
     access: public
+  - name: github


### PR DESCRIPTION
This is why we don't see the releases on GitHub releases page and changlog links have `null` in them.