### PR TITLE
build: Add missing tagging for nightly

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,6 +31,7 @@ steps:
     - |
       # Only push to Docker Hub from master
       [ "$BRANCH_NAME" != "master" ] && exit 0
+      docker tag us.gcr.io/$PROJECT_ID/chartcuterie:$COMMIT_SHA us.gcr.io/$PROJECT_ID/chartcuterie:nightly
       docker push us.gcr.io/$PROJECT_ID/chartcuterie:nightly
       echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
       docker tag us.gcr.io/$PROJECT_ID/chartcuterie:$COMMIT_SHA getsentry/chartcuterie:$SHORT_SHA


### PR DESCRIPTION
It wasn't actually tagging the nightly build