### PR TITLE
feat: Add config polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,26 +12,20 @@
     "build": "tsc",
     "watch": "tsc-watch"
   },
-  "files": [
-    "lib/**/*",
-    "fonts/**/*",
-    "package.json",
-    "LICENSE",
-    "README"
-  ],
+  "files": ["lib/**/*", "fonts/**/*", "package.json", "LICENSE", "README"],
   "dependencies": {
     "@sentry/node": "^6.2.0",
     "@types/echarts": "^4.9.3",
     "@types/express": "^4.17.11",
     "@types/joi": "^17.2.3",
-    "@types/node-fetch": "^2.5.8",
     "@types/yargs": "^16.0.0",
+    "abort-controller": "^3.0.0",
     "canvas": "^2.6.1",
     "dotenv": "^8.2.0",
     "echarts": "4.7.0",
     "express": "^4.17.1",
     "joi": "^17.4.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "v3.0.0-beta.9",
     "winston": "^3.3.3",
     "yargs": "^16.2.0"
   },

--- a/src/configPolling.ts
+++ b/src/configPolling.ts
@@ -1,0 +1,144 @@
+import fetch from 'node-fetch';
+
+import ConfigService from './config';
+import {logger} from './logging';
+import {PollingConfig} from './types';
+import {validateConfig} from './validate';
+
+type StartOptions = {
+  /**
+   * Immediately trigger a polling tick when starting
+   */
+  immediate: boolean;
+};
+
+/**
+ * The ConfigPoller is used for two things:
+ *
+ *  1. During boot we poll on the bootInterval to load the configuration module.
+ *     Typically this will be a fairly quick poll to boot the service ASAP.
+ *
+ *  2. After it's booted, it will switch to the idleInterval. This is typically
+ *     much slower and is intended for the service to keep in sync with updates
+ *     to the configuration.
+ *
+ * It will automatically switch from the bootInterval to idleInterval after the
+ * first configuration module is loaded.
+ */
+export default class ConfigPoller {
+  /**
+   * The ConfigService the ConfigPoller is associated to
+   */
+  #config: ConfigService;
+  /**
+   * Configuration for polling
+   */
+  #settings: PollingConfig;
+  /**
+   * Tracks reference handle of the setInterval
+   */
+  #interval: NodeJS.Timeout | null = null;
+
+  constructor(config: ConfigService, settings: PollingConfig) {
+    this.#config = config;
+    this.#settings = settings;
+  }
+
+  /**
+   * The polling interval is dependant on if we've already successfully loaded a
+   * configuration module or not.
+   */
+  get pollInterval() {
+    return this.#config.isLoaded
+      ? this.#settings.idleInterval
+      : this.#settings.bootInterval;
+  }
+
+  /**
+   * Fired when the polling interval ticks
+   */
+  #pollTick = async () => {
+    logger.debug('Polling tick...');
+
+    // Load deadline should match the polling interval
+    const loadDeadline = this.pollInterval;
+
+    let config: any = null;
+
+    try {
+      config = await this.#config.fetchConfig(loadDeadline);
+    } catch (error) {
+      const didAbort = error instanceof fetch.AbortError;
+
+      if (didAbort) {
+        logger.debug('Config resolution aborted for next polling tick');
+      } else {
+        logger.warn(`Failed to resolve config while polling with error: ${error}`);
+      }
+
+      return;
+    }
+
+    const [validConfig, errors] = validateConfig(config);
+
+    if (errors !== undefined) {
+      logger.warn(
+        this.#config.isLoaded
+          ? 'Resolved NEW but INVALID config. Not updating...'
+          : 'Resolved INVALID config during boot! Trying again in XXXXXXXXX'
+      );
+
+      // TODO(epurkhiser): It's likely we need to yell a little louder here
+      // if we've loaded an invalid configuration.
+
+      return;
+    }
+
+    if (validConfig.version === this.#config.version) {
+      logger.debug('Resolved the SAME configuration via polling. Nothing to do.');
+      return;
+    }
+
+    logger.info(
+      `Resolved new config via polling: ${validConfig.renderConfig.size} styles available.`,
+      {version: validConfig.version}
+    );
+
+    const wasBootPolling = !this.#config.isLoaded;
+
+    // Successful configuration update!
+    this.#config.setVersion(validConfig.version);
+    this.#config.setRenderConfig(validConfig.renderConfig);
+
+    // Switch to idle polling,
+    if (wasBootPolling) {
+      logger.info('Config polling switching to idle mode');
+
+      this.stopPolling();
+      this.startPolling({immediate: false});
+    }
+  };
+
+  /**
+   * Poll to load + update the specified configuration module
+   */
+  startPolling({immediate}: StartOptions) {
+    if (immediate) {
+      this.#pollTick();
+    }
+
+    logger.info(`Polling every ${this.pollInterval / 1000}s for config...`);
+    this.#interval = setInterval(this.#pollTick, this.pollInterval);
+  }
+
+  /**
+   * Stops polling for configuration module updates
+   */
+  stopPolling() {
+    if (this.#interval === null) {
+      return;
+    }
+
+    clearTimeout(this.#interval);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,21 @@ import ConfigService from './config';
 import * as logging from './logging';
 import {renderServer} from './renderServer';
 import {renderStream} from './renderStream';
+import {PollingConfig} from './types';
 
 dotenv.config();
 Sentry.init({dsn: process.env.SENTRY_DSN});
+
+const defaultPollingConfig: PollingConfig = {
+  /**
+   * Poll ever 5 seconds on boot
+   */
+  bootInterval: 5 * 1000,
+  /**
+   * Poll ever 5min after the first config has been loaded
+   */
+  idleInterval: 300 * 1000,
+};
 
 yargsInit(process.argv.slice(2))
   .env('CHARTCUTERIE')
@@ -37,6 +49,11 @@ yargsInit(process.argv.slice(2))
           desc: 'Port to run the webserver on',
           default: 8000,
         })
+        .option('configPolling', {
+          desc: 'Poll for new configuration updates',
+          type: 'boolean',
+          default: false,
+        })
         .coerce('port', Number);
     },
     async argv => {
@@ -44,7 +61,12 @@ yargsInit(process.argv.slice(2))
       logging.registerConsoleLogger();
 
       const config = new ConfigService(argv.config);
-      await config.resolve();
+
+      if (!argv.configPolling) {
+        await config.resolveEnsured();
+      } else {
+        config.resolveWithPolling(defaultPollingConfig);
+      }
 
       const server = renderServer(config);
       server.listen(argv.port as number);
@@ -63,7 +85,7 @@ yargsInit(process.argv.slice(2))
       logging.registerConsoleLogger({stderrLevels: ['error', 'info', 'debug']});
 
       const config = new ConfigService(argv.config);
-      await config.resolve();
+      await config.resolveEnsured();
 
       renderStream(config);
     }

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -18,6 +18,11 @@ export function renderServer(config: ConfigService) {
   app.use(Sentry.Handlers.requestHandler());
 
   app.post('/render', async (req, resp) => {
+    if (!config.isLoaded) {
+      resp.status(503).send();
+      return;
+    }
+
     const startMark = performance.now();
     const data = req.body;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,3 +59,19 @@ export type ChartcuterieConfig = {
    */
   version: string;
 };
+
+/**
+ * Configuration to specify how often to poll for configuration changes
+ */
+export type PollingConfig = {
+  /**
+   * The number of seconds between each polling attempt when the application boots
+   * and has yet to load a configuration.
+   */
+  bootInterval: number;
+  /**
+   * The number of seconds between each polling attempt after the application
+   * has already loaded a valid configuration file
+   */
+  idleInterval: number;
+};

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -27,7 +27,7 @@ describe('config', () => {
     );
 
     const config = new ConfigService('myConfig');
-    await config.resolve();
+    await config.resolveEnsured();
 
     expect(config.getConfig('fileExample')?.height).toEqual(200);
   });
@@ -47,7 +47,7 @@ describe('config', () => {
     fetchMock.mockResponse(configModule);
 
     const config = new ConfigService('https://example.com/myConfig.js');
-    await config.resolve();
+    await config.resolveEnsured();
 
     expect(fetchMock.mock.calls[0][0]).toEqual('https://example.com/myConfig.js');
     expect(config.getConfig('example')?.height).toEqual(100);

--- a/tests/configPolling.spec.ts
+++ b/tests/configPolling.spec.ts
@@ -1,0 +1,88 @@
+import {NO_VERSION} from 'app/config';
+import ConfigPoller from 'app/configPolling';
+import {PollingConfig} from 'app/types';
+
+describe('configPoller', () => {
+  jest.useFakeTimers();
+
+  const testConfig: PollingConfig = {
+    bootInterval: 5,
+    idleInterval: 20,
+  };
+
+  it('continuously resolves config via polling', async () => {
+    const mockConfigService = {
+      fetchConfig: jest.fn(),
+      setVersion: jest.fn(),
+      setRenderConfig: jest.fn(),
+      isLoaded: false,
+      version: NO_VERSION as any,
+    };
+
+    mockConfigService.setVersion.mockImplementation((version: string) => {
+      mockConfigService.isLoaded = true;
+      mockConfigService.version = version;
+    });
+
+    const renderConfig = new Map();
+    renderConfig.set('fileExample', {
+      key: 'fileExample',
+      height: 200,
+      width: 100,
+      getOption: (series: any) => ({series}),
+    });
+
+    const poller = new ConfigPoller(mockConfigService as any, testConfig);
+    mockConfigService.fetchConfig.mockReturnValue(null);
+
+    // Boots and immediately fetches config. Does not yet resolve a config yet
+    // as fetchConfig returns an invalid config.
+    poller.startPolling({immediate: true});
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledTimes(1);
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledWith(5);
+
+    // Next tick loads the config
+    mockConfigService.fetchConfig.mockReturnValue({renderConfig, version: 'abc'});
+    jest.advanceTimersByTime(5);
+    await Promise.resolve();
+
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledTimes(2);
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledWith(5);
+
+    expect(mockConfigService.setVersion).toHaveBeenCalledWith('abc');
+    expect(mockConfigService.setRenderConfig).toHaveBeenCalledWith(renderConfig);
+
+    // Configuration has been loaded
+    mockConfigService.isLoaded = true;
+    mockConfigService.setVersion.mockClear();
+
+    // Is no longer polling for boot
+    jest.advanceTimersByTime(5);
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledTimes(2);
+
+    // Next polling tick happens at 20 seconds
+    jest.advanceTimersByTime(15);
+    await Promise.resolve();
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledTimes(3);
+
+    // No new version is loaded, we resolve the same configuration version
+    expect(mockConfigService.setVersion).not.toHaveBeenCalled();
+
+    // Setup new config version for next polling tick
+    mockConfigService.fetchConfig.mockReturnValue({renderConfig, version: 'def'});
+    jest.advanceTimersByTime(20);
+    await Promise.resolve();
+
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledTimes(4);
+    expect(mockConfigService.setVersion).toHaveBeenCalledWith('def');
+
+    // Resolve invalid config, ensure we don't overwrite the active config
+    mockConfigService.setVersion.mockClear();
+    mockConfigService.fetchConfig.mockReturnValue({renderConfig, version: null});
+    jest.advanceTimersByTime(20);
+    await Promise.resolve();
+
+    expect(mockConfigService.fetchConfig).toHaveBeenCalledTimes(5);
+    expect(mockConfigService.setVersion).not.toHaveBeenCalled();
+  });
+});

--- a/tests/renderServer.spec.ts
+++ b/tests/renderServer.spec.ts
@@ -8,7 +8,7 @@ describe('renderServer', () => {
   describe('POST /render', () => {
     const config = new ConfigService('./example');
     config.setVersion('1.0-test');
-    config.setRenderConfig('dayChart', {
+    config.setRenderStyle('dayChart', {
       key: 'dayChart',
       height: 250,
       width: 400,

--- a/tests/renderStream.spec.ts
+++ b/tests/renderStream.spec.ts
@@ -11,7 +11,7 @@ jest.mock('fs');
 describe('renderStream', () => {
   it('can render graphs given a valid config and render data', async () => {
     const config = new ConfigService('./example');
-    config.setRenderConfig('dayChart', {
+    config.setRenderStyle('dayChart', {
       key: 'dayChart',
       height: 250,
       width: 400,

--- a/tests/validate.spec.ts
+++ b/tests/validate.spec.ts
@@ -39,7 +39,7 @@ describe('validate', () => {
 
   it('validates render data', () => {
     const config = new ConfigService('./example.js');
-    config.setRenderConfig(
+    config.setRenderStyle(
       'example',
       validConfig.renderConfig.example as RenderDescriptor
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,14 +755,6 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
-"@types/node-fetch@^2.5.8":
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
-  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*":
   version "14.14.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"
@@ -933,6 +925,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 accepts@~1.3.7:
   version "1.3.7"
@@ -1910,6 +1909,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -2528,6 +2532,11 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 events@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
@@ -2724,6 +2733,11 @@ fecha@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
   integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
+
+fetch-blob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-2.1.1.tgz#a54ab0d5ed7ccdb0691db77b6674308b23fb2237"
+  integrity sha512-Uf+gxPCe1hTOFXwkxYyckn8iUSk6CFXGy5VENZKifovUTZC9eUODWSBhOBS7zICGrAetKzdwLMr85KhIcePMAQ==
 
 figures@^2.0.0:
   version "2.0.0"
@@ -4442,10 +4456,18 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-fetch@2.6.1, node-fetch@^2.6.1:
+node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@v3.0.0-beta.9:
+  version "3.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0-beta.9.tgz#0a7554cfb824380dd6812864389923c783c80d9b"
+  integrity sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==
+  dependencies:
+    data-uri-to-buffer "^3.0.1"
+    fetch-blob "^2.1.1"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Adds a `--configPolling flag to the server command, that will poll for config resolution. This allows the configuration be updated by publishing a new valid configuration module to the well known URL the service is configured for.

Polling during boot before it initally has a config happens every 5 seconds. Once booted it will poll for a new config file ever 5 minutes.