### PR TITLE
new health check live and ready endpoints

### DIFF
--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -70,9 +70,9 @@ export function renderServer(config: ConfigService) {
     });
   });
 
-  app.get('/live-check', (_req, resp) => resp.status(200).send('OK'));
+  app.get('/api/chartcuterie/healthcheck/live', (_req, resp) => resp.status(200).send('OK'));
 
-  app.get('/health-check', (_req, resp) =>
+  app.get('/api/chartcuterie/healthcheck/ready', (_req, resp) =>
     config.isLoaded
       ? resp.status(200).send('OK')
       : resp.status(503).send('NOT CONFIGURED')

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -70,7 +70,9 @@ export function renderServer(config: ConfigService) {
     });
   });
 
-  app.get('/api/chartcuterie/healthcheck/live', (_req, resp) => resp.status(200).send('OK'));
+  app.get('/api/chartcuterie/healthcheck/live', (_req, resp) =>
+    resp.status(200).send('OK')
+  );
 
   app.get('/api/chartcuterie/healthcheck/ready', (_req, resp) =>
     config.isLoaded

--- a/tests/renderServer.spec.ts
+++ b/tests/renderServer.spec.ts
@@ -62,23 +62,23 @@ describe('renderServer', () => {
     });
   });
 
-  describe('GET /health-check', () => {
+  describe('GET /api/chartcuterie/healthcheck/live', () => {
     it('Responds 200 OK when configured', async () => {
       const config = new ConfigService('./example');
       config.setVersion('1.0-test');
 
       const app = renderServer(config);
-      const resp = await supertest(app).get('/health-check').send();
+      const resp = await supertest(app).get('/api/chartcuterie/healthcheck/live').send();
 
       expect(resp.status).toBe(200);
       expect(resp.text).toBe('OK');
     });
 
     it("503's before the config is loaded", async () => {
-      const config = new ConfigService('./example');
+      const config = new ConfigService('/api/chartcuterie/healthcheck/ready');
 
       const app = renderServer(config);
-      const resp = await supertest(app).get('/health-check').send();
+      const resp = await supertest(app).get('/api/chartcuterie/healthcheck/ready').send();
 
       expect(resp.status).toBe(503);
       expect(resp.text).toBe('NOT CONFIGURED');


### PR DESCRIPTION
This is to match `relay` : 
https://github.com/getsentry/single-tenant/blob/master/k8s/relay/deployment.yaml#L66-L74

sorry for the extra work. Should have caught this before the last PR