### PR TITLE
fix(http-config): Pull default from module exports

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ async function loadViaHttp(url: string, ac?: AbortController) {
   const module = {exports};
   vm.runInNewContext(configJavascript, {require, console, module, exports});
 
-  return exports.default ?? module.exports;
+  return exports.default ?? module.exports?.default ?? module.exports;
 }
 
 /**


### PR DESCRIPTION
In webpack4 the module we were building had a different output structure I think..