### PR TITLE
chore: Add sentry tracing package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@sentry/node": "^6.2.0",
+    "@sentry/tracing": "^6.11.0",
     "@types/echarts": "^4.9.3",
     "@types/express": "^4.17.11",
     "@types/joi": "^17.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import * as Sentry from '@sentry/node';
 import dotenv from 'dotenv';
 import yargs from 'yargs';
 
@@ -10,6 +11,7 @@ import {renderStream} from './renderStream';
 import {PollingConfig} from './types';
 
 dotenv.config();
+Sentry.init({dsn: process.env.SENTRY_DSN});
 
 const defaultPollingConfig: PollingConfig = {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import {renderServer} from './renderServer';
 import {renderStream} from './renderStream';
 import {PollingConfig} from './types';
 
+require('@sentry/tracing');
+
 dotenv.config();
 Sentry.init({dsn: process.env.SENTRY_DSN});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import * as Sentry from '@sentry/node';
 import dotenv from 'dotenv';
 import yargs from 'yargs';
 
@@ -10,10 +9,7 @@ import {renderServer} from './renderServer';
 import {renderStream} from './renderStream';
 import {PollingConfig} from './types';
 
-require('@sentry/tracing');
-
 dotenv.config();
-Sentry.init({dsn: process.env.SENTRY_DSN});
 
 const defaultPollingConfig: PollingConfig = {
   /**

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -2,6 +2,7 @@ import {performance} from 'perf_hooks';
 
 import * as Sentry from '@sentry/node';
 import express from 'express';
+import { Integrations } from "@sentry/tracing";
 
 import ConfigService from './config';
 import {logger} from './logging';
@@ -14,8 +15,19 @@ import {validateRenderData} from './validate';
 export function renderServer(config: ConfigService) {
   const app = express();
 
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    tracesSampleRate: 0,
+    integrations: [
+      new Integrations.Express({app}),
+    ],
+  });
+
+
   app.use(express.json({limit: '20mb'}));
   app.use(Sentry.Handlers.requestHandler());
+  app.use(Sentry.Handlers.tracingHandler());
 
   app.post('/render', async (req, resp) => {
     if (!config.isLoaded) {

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -1,8 +1,8 @@
 import {performance} from 'perf_hooks';
 
 import * as Sentry from '@sentry/node';
+import {Integrations} from '@sentry/tracing';
 import express from 'express';
-import { Integrations } from "@sentry/tracing";
 
 import ConfigService from './config';
 import {logger} from './logging';
@@ -15,15 +15,11 @@ import {validateRenderData} from './validate';
 export function renderServer(config: ConfigService) {
   const app = express();
 
-
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0,
-    integrations: [
-      new Integrations.Express({app}),
-    ],
+    integrations: [new Integrations.Express({app})],
   });
-
 
   app.use(express.json({limit: '20mb'}));
   app.use(Sentry.Handlers.requestHandler());

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -22,7 +22,7 @@ export function renderServer(config: ConfigService) {
         new Integrations.Express({app}),
         new Sentry.Integrations.Http({ tracing: true }),
       ],
-      tracesSampleRate: 1.0,
+      tracesSampleRate: 0,
     })
   );
 

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -20,7 +20,7 @@ export function renderServer(config: ConfigService) {
       dsn: process.env.SENTRY_DSN,
       integrations: [
         new Integrations.Express({app}),
-        new Sentry.Integrations.Http({ tracing: true }),
+        new Sentry.Integrations.Http({tracing: true}),
       ],
       tracesSampleRate: 0,
     })

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -15,11 +15,13 @@ import {validateRenderData} from './validate';
 export function renderServer(config: ConfigService) {
   const app = express();
 
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    tracesSampleRate: 0,
-    integrations: [new Integrations.Express({app})],
-  });
+  Sentry.getCurrentHub().bindClient(
+    new Sentry.NodeClient({
+      dsn: process.env.SENTRY_DSN,
+      integrations: [new Integrations.Express({app})],
+      tracesSampleRate: 1.0,
+    })
+  );
 
   app.use(express.json({limit: '20mb'}));
   app.use(Sentry.Handlers.requestHandler());

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -18,7 +18,10 @@ export function renderServer(config: ConfigService) {
   Sentry.getCurrentHub().bindClient(
     new Sentry.NodeClient({
       dsn: process.env.SENTRY_DSN,
-      integrations: [new Integrations.Express({app})],
+      integrations: [
+        new Integrations.Express({app}),
+        new Sentry.Integrations.Http({ tracing: true }),
+      ],
       tracesSampleRate: 1.0,
     })
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,15 @@
     "@sentry/utils" "6.2.0"
     tslib "^1.9.3"
 
+"@sentry/hub@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
+  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
 "@sentry/hub@6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.0.tgz#e7502652bc9608cf8fb63e43cd49df9019a28f29"
@@ -525,6 +534,15 @@
   dependencies:
     "@sentry/types" "6.2.0"
     "@sentry/utils" "6.2.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
+  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
 "@sentry/minimal@6.2.0":
@@ -562,10 +580,34 @@
     "@sentry/utils" "6.2.0"
     tslib "^1.9.3"
 
+"@sentry/tracing@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.11.0.tgz#9bd9287addea1ebc12c75b226f71c7713c0fac4f"
+  integrity sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/types@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
+  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
+
 "@sentry/types@6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.0.tgz#ca020ff42913c6b9f88a9d0c375b5ee3965a2590"
   integrity sha512-vN4P/a+QqAuVfWFB9G3nQ7d6bgnM9jd/RLVi49owMuqvM24pv5mTQHUk2Hk4S3k7ConrHFl69E7xH6Dv5VpQnQ==
+
+"@sentry/utils@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
+  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
 
 "@sentry/utils@6.2.0":
   version "6.2.0"


### PR DESCRIPTION
Initialize sentry right after express app is initialized, add tracing handler
Related [PR](https://github.com/getsentry/sentry/pull/28114)