### PR TITLE
chore(tracing): Set tracing sample rate to 1

### DIFF
--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -22,7 +22,7 @@ export function renderServer(config: ConfigService) {
         new Integrations.Express({app}),
         new Sentry.Integrations.Http({tracing: true}),
       ],
-      tracesSampleRate: 0,
+      tracesSampleRate: 1,
     })
   );
 


### PR DESCRIPTION
Trying to prove that traces get sent to
Sentry if sampling is set to 1. This is to
narrow down tracing issues to the tracing
headers not being set properly or tracing
cross origins.