### PR TITLE
debug: Log invalid config errors

### DIFF
--- a/src/configPolling.ts
+++ b/src/configPolling.ts
@@ -84,7 +84,7 @@ export default class ConfigPoller {
     if (errors !== undefined) {
       logger.warn(
         this.#config.isLoaded
-          ? 'Resolved NEW but INVALID config. Not updating...'
+          ? `Resolved NEW but INVALID config (${errors}). Not updating...`
           : `Resolved INVALID config during boot (${errors}). Trying again in ${
               this.pollInterval / 1000
             }s`


### PR DESCRIPTION
Log invalid config errors.

World map chart unfurls don't work, because
[chartcuterie isn't picking up world map type](https://sentry.io/organizations/sentry/discover/sentry:c0a282fec19847189a4f305105b90dc1/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=1&query=&sort=-timestamp&statsPeriod=1h&yAxis=count%28%29). Tracked
down some GCP logs, seeing the following:
`[33mwarn [39m: Resolved NEW but INVALID config. Not updating...`

Not able to replicate this locally either. To replicate
locally, enabled polling with `--configPolling=true`
when starting up the service, reduced the default polling
time and added a `delete require.cache[path.resolve(this.#uri)];`
in fetchConfig so it would read any new updates to the file.
Started without the world map, then replaced the contents in my
local config.js file with the contents of `chartcuterie-config.js`
returned by sentry in the http request on prod. But
that didn't cause any hiccups either.

Logs from local chartcuterie. Note the "Resolved new config via
polling: 7 styles available." towards the end.
```
info: Polling every 5s for config...
info: Server listening for render requests on port 7901
info: Resolved new config via polling: 6 styles available. {"version":"6776229fbde4ca8cd52884d369a1b498a43dc6b4"}
info: Config polling switching to idle mode
info: Polling every 10s for config...
debug: Polling tick...
Error: Locale not set, defaulting to English
    at getClient (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:89242:21)
    at gettext (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:89490:15)
    at /Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:89750:9
    at /Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:92475:3
    at Object.<anonymous> (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:92478:12)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
debug: Resolved the SAME configuration via polling. Nothing to do.
debug: Polling tick...
Error: Locale not set, defaulting to English
    ...
debug: Resolved the SAME configuration via polling. Nothing to do.
debug: Polling tick...
Error: Locale not set, defaulting to English
    at getClient (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:5342:21)
    at gettext (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:5590:15)
    at Module.87930 (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:5850:9)
    at __webpack_require__ (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:96679:42)
    at /Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:96788:37
    at Object.<anonymous> (/Users/shruthilayajaganathan/code/sentry/config/chartcuterie/config.js:96791:12)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
info: Resolved new config via polling: 7 styles available. {"version":"a55174c3b716039d5a3f20613f77157153298c2c"}
debug: Polling tick...
Error: Locale not set, defaulting to English
    ...
debug: Resolved the SAME configuration via polling. Nothing to do.
```

The local docker container for chartcuterie also boots up no
problem with the world map charts (that's how tests
passed in CI too)