### PR TITLE
chore: Sentry SDK 7.0.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@sentry/node": "7.0.0-beta.2",
-    "@sentry/tracing": "^6.11.0",
+    "@sentry/tracing": "7.0.0-beta.2",
     "@types/express": "^4.17.11",
     "@types/joi": "^17.2.3",
     "@types/yargs": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "7.0.0-beta.2",
-    "@sentry/tracing": "7.0.0-beta.2",
+    "@sentry/node": "7.0.0-rc.0",
+    "@sentry/tracing": "7.0.0-rc.0",
     "@types/express": "^4.17.11",
     "@types/joi": "^17.2.3",
     "@types/yargs": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "^6.2.0",
+    "@sentry/node": "7.0.0-beta.1",
     "@sentry/tracing": "^6.11.0",
     "@types/express": "^4.17.11",
     "@types/joi": "^17.2.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "7.0.0-beta.1",
+    "@sentry/node": "7.0.0-beta.2",
     "@sentry/tracing": "^6.11.0",
     "@types/express": "^4.17.11",
     "@types/joi": "^17.2.3",

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -15,16 +15,14 @@ import {validateRenderData} from './validate';
 export function renderServer(config: ConfigService) {
   const app = express();
 
-  Sentry.getCurrentHub().bindClient(
-    new Sentry.NodeClient({
-      dsn: process.env.SENTRY_DSN,
-      integrations: [
-        new Integrations.Express({app}),
-        new Sentry.Integrations.Http({tracing: true}),
-      ],
-      tracesSampleRate: 1,
-    })
-  );
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: [
+      new Integrations.Express({app}),
+      new Sentry.Integrations.Http({tracing: true}),
+    ],
+    tracesSampleRate: 1,
+  });
 
   app.use(express.json({limit: '20mb'}));
   app.use(Sentry.Handlers.requestHandler());

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,60 +522,60 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@sentry/core@7.0.0-beta.2":
-  version "7.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0-beta.2.tgz#e16e47790523522963f0b96656b0817fbecaf204"
-  integrity sha512-trJa+P/w5g4P2/rVDXC9ZAwx8rH/Q354n2COO8DQcHMG2jLA1B8c7GxiO0zq+Uoe+xz8lq+hVAkC0aLgtRia9w==
+"@sentry/core@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0-rc.0.tgz#f3984d8fd4302ee6ada45ab667165b5adcc482f6"
+  integrity sha512-uoYH2O9groVZU9IelT8mLC/qFpHQxpqUGu+Ei21bB4P4nUJYjL4GpWV0DsgWuZp4zk4BoTn7V98pc19p5M3aWg==
   dependencies:
-    "@sentry/hub" "7.0.0-beta.2"
-    "@sentry/types" "7.0.0-beta.2"
-    "@sentry/utils" "7.0.0-beta.2"
+    "@sentry/hub" "7.0.0-rc.0"
+    "@sentry/types" "7.0.0-rc.0"
+    "@sentry/utils" "7.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/hub@7.0.0-beta.2":
-  version "7.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0-beta.2.tgz#6eb172f89ae28a032d1ed6a779899fc9478cd0b7"
-  integrity sha512-SRXKzTrZneBXmHLGLHU+Pw+7tRtltUDzK7NIlHuzZGh8HQf8i0v/wDmorNaVL+GkkggzutH/Bdf8bXuHkjtzNg==
+"@sentry/hub@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0-rc.0.tgz#d6575061847619a0913dc034ec1f564be539ea7f"
+  integrity sha512-8OZbfCO4W10VUC/S8SFiEeI3EmigDRJc7gSn1kpNfI0jQIRsl8ivuJTuyhSrsQiEXt0c0wxXn3Wy8+FLLycgYg==
   dependencies:
-    "@sentry/types" "7.0.0-beta.2"
-    "@sentry/utils" "7.0.0-beta.2"
+    "@sentry/types" "7.0.0-rc.0"
+    "@sentry/utils" "7.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.0.0-beta.2":
-  version "7.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.0.0-beta.2.tgz#99f42648de08d17e9f111aee44503e581caa4de4"
-  integrity sha512-2cPlziqb2+WeAMyXQSv+XfRQNB9f4jRmXvcn7sNplUgtPPFTbjjizHHhYvw7grCjwYkZDGhKSJDxEqTfQZXcaA==
+"@sentry/node@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.0.0-rc.0.tgz#8d02c5a71f704487449a7b2dd4ece6769e77552d"
+  integrity sha512-flf5mmBipyWNFyxt1HOUIMVpacWIDmQgjmfKQ1VL+IApJN71F0JWL10Llqe7NXY5McqlmQy8489c4m8Hps5XzA==
   dependencies:
-    "@sentry/core" "7.0.0-beta.2"
-    "@sentry/hub" "7.0.0-beta.2"
-    "@sentry/types" "7.0.0-beta.2"
-    "@sentry/utils" "7.0.0-beta.2"
+    "@sentry/core" "7.0.0-rc.0"
+    "@sentry/hub" "7.0.0-rc.0"
+    "@sentry/types" "7.0.0-rc.0"
+    "@sentry/utils" "7.0.0-rc.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@7.0.0-beta.2":
-  version "7.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.0.0-beta.2.tgz#2e948da3d8d73913490901293db82a2b69ba05d5"
-  integrity sha512-e8jlC6y1Se4K8MdFigucA27TTriuCNACQOzkfN3YLgYJii2AB+Iz9XUAmfpmpzpejGEKC7IaaaBrbRPnUc3hxQ==
+"@sentry/tracing@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.0.0-rc.0.tgz#616e8f8c101106f273a0ac4a5f8f80affe767db3"
+  integrity sha512-1o3XgVkfUBy1bpG2g3p+0orwhFgThwc8Om6nWeto3mVsVGZzmxGi3SmvxG5JZ0I0j0nMAOL9O+N9c5LWxBeSrA==
   dependencies:
-    "@sentry/hub" "7.0.0-beta.2"
-    "@sentry/types" "7.0.0-beta.2"
-    "@sentry/utils" "7.0.0-beta.2"
+    "@sentry/hub" "7.0.0-rc.0"
+    "@sentry/types" "7.0.0-rc.0"
+    "@sentry/utils" "7.0.0-rc.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.0.0-beta.2":
-  version "7.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0-beta.2.tgz#f836784930b5cb64ba13602f0ec3e6110f430c9c"
-  integrity sha512-nU9BT/kBy6sQfq0M0s+LzGrjg8ELofOubhPwX1RZC0cPsUzKbFPCISnikbQJDC7J0Kg0TpQrGs/FP0mFxp3ItA==
+"@sentry/types@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0-rc.0.tgz#ec6e6503d76157bc35df625dc514aecbd890ee91"
+  integrity sha512-6TGWcMRLjdGo162qflzA8trQS4ziqymU4zqCvahpU7QlzHXF0Pct0xBNphvf6p6l3y54Mf6YQBomqUHthcYCEA==
 
-"@sentry/utils@7.0.0-beta.2":
-  version "7.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0-beta.2.tgz#6edb5f80873980618c5f9b8fd4f96b9c8236b0f9"
-  integrity sha512-2PO0bRYBoWr/PWs7kCFuLK+lZ0F0B6O45oen8HK+YeizCaat6dlcu3/QNpFjv+lWVh6gDUgQ9nmQuO4L5a2dJA==
+"@sentry/utils@7.0.0-rc.0":
+  version "7.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0-rc.0.tgz#d16c998db7ad07dacd78c6a64109b3857edfeffd"
+  integrity sha512-ZMRPcoLeXEXlltv48wpkJzGYC0JUYqzvFMJqzRfXyfwUi2HyVjHRRR8LqFbVP40qZkwLHyC1aXyov1L6kG+n5g==
   dependencies:
-    "@sentry/types" "7.0.0-beta.2"
+    "@sentry/types" "7.0.0-rc.0"
     tslib "^1.9.3"
 
 "@sideway/address@^4.1.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,14 +522,14 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@sentry/core@7.0.0-beta.1":
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0-beta.1.tgz#254b3707adf39b6e8645f95f4a5b0f2520b973db"
-  integrity sha512-NPZRb5PSxnV5s4rOiWCO5VgTAjAD+UGsClgCq/3V15/6WZfD6ogCBx+kQ6cfWCE+zvjQezpWm1+ndXvAo1iPFw==
+"@sentry/core@7.0.0-beta.2":
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0-beta.2.tgz#e16e47790523522963f0b96656b0817fbecaf204"
+  integrity sha512-trJa+P/w5g4P2/rVDXC9ZAwx8rH/Q354n2COO8DQcHMG2jLA1B8c7GxiO0zq+Uoe+xz8lq+hVAkC0aLgtRia9w==
   dependencies:
-    "@sentry/hub" "7.0.0-beta.1"
-    "@sentry/types" "7.0.0-beta.1"
-    "@sentry/utils" "7.0.0-beta.1"
+    "@sentry/hub" "7.0.0-beta.2"
+    "@sentry/types" "7.0.0-beta.2"
+    "@sentry/utils" "7.0.0-beta.2"
     tslib "^1.9.3"
 
 "@sentry/hub@6.11.0":
@@ -541,13 +541,13 @@
     "@sentry/utils" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/hub@7.0.0-beta.1":
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0-beta.1.tgz#b2f85827b8229432c9bef26e579bcad779e7d783"
-  integrity sha512-FRm1V9t7WD5jilJCiQms1I8LWiGDVekuOBy6RbQG0tEQGP6LrdoGHOYX5B56fabvQl7l2V4Cuykws59IKH9tNg==
+"@sentry/hub@7.0.0-beta.2":
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0-beta.2.tgz#6eb172f89ae28a032d1ed6a779899fc9478cd0b7"
+  integrity sha512-SRXKzTrZneBXmHLGLHU+Pw+7tRtltUDzK7NIlHuzZGh8HQf8i0v/wDmorNaVL+GkkggzutH/Bdf8bXuHkjtzNg==
   dependencies:
-    "@sentry/types" "7.0.0-beta.1"
-    "@sentry/utils" "7.0.0-beta.1"
+    "@sentry/types" "7.0.0-beta.2"
+    "@sentry/utils" "7.0.0-beta.2"
     tslib "^1.9.3"
 
 "@sentry/minimal@6.11.0":
@@ -559,15 +559,15 @@
     "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/node@7.0.0-beta.1":
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.0.0-beta.1.tgz#2c4c7a40d25a1e395dddaf68ca0fb874bde8dff6"
-  integrity sha512-iOWqfZQbKYMgVXeIW9zavKiXCBeRtbzBi+KZwRKGZ5GWkYjHsgy7g9r+OHIDoiZnlcPUJUn1+iEEn6IB0mpgag==
+"@sentry/node@7.0.0-beta.2":
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.0.0-beta.2.tgz#99f42648de08d17e9f111aee44503e581caa4de4"
+  integrity sha512-2cPlziqb2+WeAMyXQSv+XfRQNB9f4jRmXvcn7sNplUgtPPFTbjjizHHhYvw7grCjwYkZDGhKSJDxEqTfQZXcaA==
   dependencies:
-    "@sentry/core" "7.0.0-beta.1"
-    "@sentry/hub" "7.0.0-beta.1"
-    "@sentry/types" "7.0.0-beta.1"
-    "@sentry/utils" "7.0.0-beta.1"
+    "@sentry/core" "7.0.0-beta.2"
+    "@sentry/hub" "7.0.0-beta.2"
+    "@sentry/types" "7.0.0-beta.2"
+    "@sentry/utils" "7.0.0-beta.2"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
@@ -589,10 +589,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
   integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
 
-"@sentry/types@7.0.0-beta.1":
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0-beta.1.tgz#23a41bda2edd09f7f51f257bb6e2e6d82803f44f"
-  integrity sha512-5WHtDE0ggVWvdny6dheJjtVej/hMB24G7MtvA7n55y2RuFM5EdujXjsYEwWvbS8BnoYi9cBRco7LEour6Pv/YA==
+"@sentry/types@7.0.0-beta.2":
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0-beta.2.tgz#f836784930b5cb64ba13602f0ec3e6110f430c9c"
+  integrity sha512-nU9BT/kBy6sQfq0M0s+LzGrjg8ELofOubhPwX1RZC0cPsUzKbFPCISnikbQJDC7J0Kg0TpQrGs/FP0mFxp3ItA==
 
 "@sentry/utils@6.11.0":
   version "6.11.0"
@@ -602,12 +602,12 @@
     "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/utils@7.0.0-beta.1":
-  version "7.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0-beta.1.tgz#507cf15c82cb486c8f30c1f5d36d6f0149872074"
-  integrity sha512-wI9KfieQvoO2+2QUzNpOoJvvcnLkovQFjsmkaqcAjNhwhA9Z1kg0TdqJSETQwNJ+6LD+XFOABSWV3Zw8dzbcmA==
+"@sentry/utils@7.0.0-beta.2":
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0-beta.2.tgz#6edb5f80873980618c5f9b8fd4f96b9c8236b0f9"
+  integrity sha512-2PO0bRYBoWr/PWs7kCFuLK+lZ0F0B6O45oen8HK+YeizCaat6dlcu3/QNpFjv+lWVh6gDUgQ9nmQuO4L5a2dJA==
   dependencies:
-    "@sentry/types" "7.0.0-beta.1"
+    "@sentry/types" "7.0.0-beta.2"
     tslib "^1.9.3"
 
 "@sideway/address@^4.1.0":
@@ -1819,9 +1819,9 @@ cookie@0.4.0:
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
 cookie@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cookiejar@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,15 +522,14 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@sentry/core@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.0.tgz#be1c33854fc94e1a4d867f7c2c311cf1cefb8ee9"
-  integrity sha512-oTr2b25l+0bv/+d6IgMamPuGleWV7OgJb0NFfd+WZhw6UDRgr7CdEJy2gW6tK8SerwXgPHdn4ervxsT3WIBiXw==
+"@sentry/core@7.0.0-beta.1":
+  version "7.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0-beta.1.tgz#254b3707adf39b6e8645f95f4a5b0f2520b973db"
+  integrity sha512-NPZRb5PSxnV5s4rOiWCO5VgTAjAD+UGsClgCq/3V15/6WZfD6ogCBx+kQ6cfWCE+zvjQezpWm1+ndXvAo1iPFw==
   dependencies:
-    "@sentry/hub" "6.2.0"
-    "@sentry/minimal" "6.2.0"
-    "@sentry/types" "6.2.0"
-    "@sentry/utils" "6.2.0"
+    "@sentry/hub" "7.0.0-beta.1"
+    "@sentry/types" "7.0.0-beta.1"
+    "@sentry/utils" "7.0.0-beta.1"
     tslib "^1.9.3"
 
 "@sentry/hub@6.11.0":
@@ -542,13 +541,13 @@
     "@sentry/utils" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.0.tgz#e7502652bc9608cf8fb63e43cd49df9019a28f29"
-  integrity sha512-BDTEFK8vlJydWXp/KMX0stvv73V7od224iLi+w3k7BcPwMKXBuURBXPU8d5XIC4G8nwg8X6cnDvwL+zBBlBbkg==
+"@sentry/hub@7.0.0-beta.1":
+  version "7.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0-beta.1.tgz#b2f85827b8229432c9bef26e579bcad779e7d783"
+  integrity sha512-FRm1V9t7WD5jilJCiQms1I8LWiGDVekuOBy6RbQG0tEQGP6LrdoGHOYX5B56fabvQl7l2V4Cuykws59IKH9tNg==
   dependencies:
-    "@sentry/types" "6.2.0"
-    "@sentry/utils" "6.2.0"
+    "@sentry/types" "7.0.0-beta.1"
+    "@sentry/utils" "7.0.0-beta.1"
     tslib "^1.9.3"
 
 "@sentry/minimal@6.11.0":
@@ -560,39 +559,18 @@
     "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.0.tgz#718b70babb55912eeb38babaf7823d1bcdd77d1e"
-  integrity sha512-haxsx8/ZafhZUaGeeMtY7bJt9HbDlqeiaXrRMp1CxGtd0ZRQwHt60imEjl6IH1I73SEWxNfqScGsX2s3HzztMg==
+"@sentry/node@7.0.0-beta.1":
+  version "7.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.0.0-beta.1.tgz#2c4c7a40d25a1e395dddaf68ca0fb874bde8dff6"
+  integrity sha512-iOWqfZQbKYMgVXeIW9zavKiXCBeRtbzBi+KZwRKGZ5GWkYjHsgy7g9r+OHIDoiZnlcPUJUn1+iEEn6IB0mpgag==
   dependencies:
-    "@sentry/hub" "6.2.0"
-    "@sentry/types" "6.2.0"
-    tslib "^1.9.3"
-
-"@sentry/node@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.2.0.tgz#4c1860822a4a73d24242e5254124bd3bf9028d52"
-  integrity sha512-02lXk+56tPA3lWTvNLMGorp77wUVti8wOs+TlYARkJ+N+16dwqEBSBTy3hCDxlxriB+qHchSIS+ovPGi6WNiYA==
-  dependencies:
-    "@sentry/core" "6.2.0"
-    "@sentry/hub" "6.2.0"
-    "@sentry/tracing" "6.2.0"
-    "@sentry/types" "6.2.0"
-    "@sentry/utils" "6.2.0"
+    "@sentry/core" "7.0.0-beta.1"
+    "@sentry/hub" "7.0.0-beta.1"
+    "@sentry/types" "7.0.0-beta.1"
+    "@sentry/utils" "7.0.0-beta.1"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
-    tslib "^1.9.3"
-
-"@sentry/tracing@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.0.tgz#76c17e5dd3f1e61c8a4e3bd090f904a63d674765"
-  integrity sha512-pzgM1dePPJysVnzaFCMp+BKtjM5q46HZeyShiR+KcQYvneD3fmUPJigDkkcsB2DcrY3mFvDcswjoqxaTIW7ZBQ==
-  dependencies:
-    "@sentry/hub" "6.2.0"
-    "@sentry/minimal" "6.2.0"
-    "@sentry/types" "6.2.0"
-    "@sentry/utils" "6.2.0"
     tslib "^1.9.3"
 
 "@sentry/tracing@^6.11.0":
@@ -611,10 +589,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
   integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
 
-"@sentry/types@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.0.tgz#ca020ff42913c6b9f88a9d0c375b5ee3965a2590"
-  integrity sha512-vN4P/a+QqAuVfWFB9G3nQ7d6bgnM9jd/RLVi49owMuqvM24pv5mTQHUk2Hk4S3k7ConrHFl69E7xH6Dv5VpQnQ==
+"@sentry/types@7.0.0-beta.1":
+  version "7.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0-beta.1.tgz#23a41bda2edd09f7f51f257bb6e2e6d82803f44f"
+  integrity sha512-5WHtDE0ggVWvdny6dheJjtVej/hMB24G7MtvA7n55y2RuFM5EdujXjsYEwWvbS8BnoYi9cBRco7LEour6Pv/YA==
 
 "@sentry/utils@6.11.0":
   version "6.11.0"
@@ -624,12 +602,12 @@
     "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/utils@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.0.tgz#39c81ad5ba92cec54d690e3fa8ea4e777d8e9c2b"
-  integrity sha512-YToUC7xYf2E/pIluI7upYTlj8fKXOtdwoOBkcQZifHgX/dP+qDaHibbBFe5PyZwdmU2UiLnWFsBr0gjo0QFo1g==
+"@sentry/utils@7.0.0-beta.1":
+  version "7.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0-beta.1.tgz#507cf15c82cb486c8f30c1f5d36d6f0149872074"
+  integrity sha512-wI9KfieQvoO2+2QUzNpOoJvvcnLkovQFjsmkaqcAjNhwhA9Z1kg0TdqJSETQwNJ+6LD+XFOABSWV3Zw8dzbcmA==
   dependencies:
-    "@sentry/types" "6.2.0"
+    "@sentry/types" "7.0.0-beta.1"
     tslib "^1.9.3"
 
 "@sideway/address@^4.1.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,15 +532,6 @@
     "@sentry/utils" "7.0.0-beta.2"
     tslib "^1.9.3"
 
-"@sentry/hub@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
-  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
-  dependencies:
-    "@sentry/types" "6.11.0"
-    "@sentry/utils" "6.11.0"
-    tslib "^1.9.3"
-
 "@sentry/hub@7.0.0-beta.2":
   version "7.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0-beta.2.tgz#6eb172f89ae28a032d1ed6a779899fc9478cd0b7"
@@ -548,15 +539,6 @@
   dependencies:
     "@sentry/types" "7.0.0-beta.2"
     "@sentry/utils" "7.0.0-beta.2"
-    tslib "^1.9.3"
-
-"@sentry/minimal@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
-  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
-  dependencies:
-    "@sentry/hub" "6.11.0"
-    "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
 "@sentry/node@7.0.0-beta.2":
@@ -573,34 +555,20 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.11.0.tgz#9bd9287addea1ebc12c75b226f71c7713c0fac4f"
-  integrity sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==
+"@sentry/tracing@7.0.0-beta.2":
+  version "7.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.0.0-beta.2.tgz#2e948da3d8d73913490901293db82a2b69ba05d5"
+  integrity sha512-e8jlC6y1Se4K8MdFigucA27TTriuCNACQOzkfN3YLgYJii2AB+Iz9XUAmfpmpzpejGEKC7IaaaBrbRPnUc3hxQ==
   dependencies:
-    "@sentry/hub" "6.11.0"
-    "@sentry/minimal" "6.11.0"
-    "@sentry/types" "6.11.0"
-    "@sentry/utils" "6.11.0"
+    "@sentry/hub" "7.0.0-beta.2"
+    "@sentry/types" "7.0.0-beta.2"
+    "@sentry/utils" "7.0.0-beta.2"
     tslib "^1.9.3"
-
-"@sentry/types@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
-  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
 
 "@sentry/types@7.0.0-beta.2":
   version "7.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0-beta.2.tgz#f836784930b5cb64ba13602f0ec3e6110f430c9c"
   integrity sha512-nU9BT/kBy6sQfq0M0s+LzGrjg8ELofOubhPwX1RZC0cPsUzKbFPCISnikbQJDC7J0Kg0TpQrGs/FP0mFxp3ItA==
-
-"@sentry/utils@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
-  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
-  dependencies:
-    "@sentry/types" "6.11.0"
-    tslib "^1.9.3"
 
 "@sentry/utils@7.0.0-beta.2":
   version "7.0.0-beta.2"


### PR DESCRIPTION
Updates @sentry/node to version 7.0.0-rc.0


@edwardgou-sentry, I branched out from your changes in #79 and updated to the newest RC to save you some time.

closes: #79 