### PR TITLE
feat: Avoid calling echarts.init with invalid data object & always dispose

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -22,8 +22,14 @@ export function renderSync(style: RenderDescriptor, data: any) {
   const canvas = createCanvas(style.width, style.height);
   const htmlCanvas = canvas as unknown as HTMLCanvasElement;
 
-  const chart = echarts.init(htmlCanvas);
-  chart.setOption({...style.getOption(data), ...disabledOptions});
+  // Get options object before echarts.init to ensure options can be created
+  const options = style.getOption(data);
 
-  return [canvas.createPNGStream(pngConfig), () => chart.dispose()] as const;
+  const chart = echarts.init(htmlCanvas);
+  chart.setOption({...options, ...disabledOptions});
+
+  return {
+    stream: canvas.createPNGStream(pngConfig),
+    dispose: () => chart.dispose(),
+  };
 }

--- a/src/renderStream.ts
+++ b/src/renderStream.ts
@@ -32,16 +32,16 @@ export async function renderStream(config: ConfigService) {
     throw new Error('Invalid config style key provided');
   }
 
-  const [stream, dispose] = renderSync(style, renderData.data);
+  const render = renderSync(style, renderData.data);
 
-  stream.pipe(process.stdout);
+  render.stream.pipe(process.stdout);
 
   try {
     await new Promise((resolve, reject) => {
-      stream.on('end', resolve);
-      stream.on('error', reject);
+      render.stream.on('end', resolve);
+      render.stream.on('error', reject);
     });
   } finally {
-    dispose();
+    render.dispose();
   }
 }


### PR DESCRIPTION
Sometimes charts have invalid data passed to the chart options function. A 500 is expected, however each request is using more memory. Either from echarts.init being called and not disposed or it was erroring creating the echarts options which was after echarts.init, also causing dispose to not be called.