### PR TITLE
feat: Switch to a buffer instead of a PNGStream

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -1,14 +1,10 @@
-import {createCanvas, PngConfig} from 'canvas';
+import {createCanvas} from 'canvas';
 import * as echarts from 'echarts';
 
 import {RenderDescriptor} from './types';
 import {disabledOptions, registerCanvasFonts} from './utils';
 
 registerCanvasFonts();
-
-const pngConfig: PngConfig = {
-  // Configure png rendering here
-};
 
 /**
  * Renders a single chart
@@ -28,7 +24,7 @@ export function renderSync(style: RenderDescriptor, data: any) {
   chart.setOption({...options, ...disabledOptions});
 
   return {
-    stream: canvas.createPNGStream(pngConfig),
+    buffer: canvas.toBuffer('image/png'),
     dispose: () => chart.dispose(),
   };
 }

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -28,7 +28,7 @@ export function renderServer(config: ConfigService) {
   renderRoutes.use(express.json({limit: '20mb'}));
   renderRoutes.use(Sentry.Handlers.requestHandler());
   renderRoutes.use(Sentry.Handlers.tracingHandler());
-  renderRoutes.use(async (req, resp) => {
+  renderRoutes.use((req, resp) => {
     if (!config.isLoaded) {
       resp.status(503).send();
       return;
@@ -61,14 +61,8 @@ export function renderServer(config: ConfigService) {
         .status(200)
         .contentType('png')
         .header('X-Config-Version', config.version.toString())
-        .attachment('chart.png');
-
-      render.stream.pipe(resp);
-
-      await new Promise((resolve, reject) => {
-        render!.stream.on('end', resolve);
-        render!.stream.on('error', reject);
-      });
+        .attachment('chart.png')
+        .send(render.buffer);
     } catch (error) {
       Sentry.captureException(error);
       resp.status(500);

--- a/src/renderStream.ts
+++ b/src/renderStream.ts
@@ -34,14 +34,6 @@ export async function renderStream(config: ConfigService) {
 
   const render = renderSync(style, renderData.data);
 
-  render.stream.pipe(process.stdout);
-
-  try {
-    await new Promise((resolve, reject) => {
-      render.stream.on('end', resolve);
-      render.stream.on('error', reject);
-    });
-  } finally {
-    render.dispose();
-  }
+  process.stdout.write(render.buffer);
+  render.dispose();
 }


### PR DESCRIPTION
i remember streams needing to be destroyed, lets try using a buffer and avoid the entire situation. We also get to remove the await on pipe