### PR TITLE
perf(echarts): pass options to init directly

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -20,8 +20,9 @@ export function renderSync(style: RenderDescriptor, data: any) {
     renderer: 'canvas',
     width: style.width,
     height: style.height,
+    ...options,
+    ...disabledOptions,
   });
-  chart.setOption({...options, ...disabledOptions});
 
   return {
     buffer: canvas.toBuffer('image/png'),


### PR DESCRIPTION
We can pass options directly to the chart.init which will avoid calling updates to all of the components and redrawing the chart