### PR TITLE
Fix names for image jobs

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
 jobs:
-  image:
+  build-image:
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -40,7 +40,7 @@ jobs:
 
   multiarch:
     if: github.event_name != 'pull_request'
-    needs: [build]
+    needs: [build-image]
     runs-on: ubuntu-latest
     steps:
     - run: |


### PR DESCRIPTION
Thought the rename was innocent, but I missed a dependency.