### PR TITLE
cd: add GoCD deployment pipeline

### DIFF
--- a/.github/workflows/lint-pipelines.sh
+++ b/.github/workflows/lint-pipelines.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# gocd-cli does not catch all errors, but does catch some simple issues.
+# A better solution may be: https://github.com/GaneshSPatil/gocd-mergeable
+
+echo "GoCD YAML Linting"
+
+find "gocd" -name "*.yaml" -type f -print0 | \
+  xargs -0 -I'{}' bash -c 'printf  "\n🔎 Linting {}\n\t" && gocd-cli configrepo syntax --yaml --raw "{}"'

--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -1,0 +1,36 @@
+name: Lint Deployment Pipelines
+
+on:
+    pull_request:
+    push:
+        branches: [main, test-me-*]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: cache bin
+              id: cache-bin
+              uses: actions/cache@v3
+              with:
+                  path: ${HOME}/.local/bin
+                  # Bump this key if you're changing gocd-cli versions.
+                  key: ${{ runner.os }}-bin
+
+            - name: Install gocd-cli
+              run: |
+                # this is on github runner's PATH but it isn't created, lol
+                mkdir -p "${HOME}/.local/bin"
+                bin="${HOME}/.local/bin/gocd-cli"
+                curl -L -o "$bin" 'https://sentry-dev-infra-assets.storage.googleapis.com/gocd-085ab00-linux-amd64'
+                echo "11d517c0c0058d1204294d01bfac987c0eaf9e37ba533ad54107b0949403321e  ${bin}" | sha256sum -c -
+                chmod +x "$bin"
+
+            - name: Lint Pipelines with gocd-cli
+              run: ./.github/workflows/lint-pipelines.sh

--- a/gocd/pipelines/chartcuterie.yaml
+++ b/gocd/pipelines/chartcuterie.yaml
@@ -10,8 +10,6 @@ pipelines:
             GKE_REGION: us-central1
             GKE_CLUSTER_ZONE: b
             GKE_BASTION_ZONE: b
-            # Read access to private repositories for the GoCD agent.
-            GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
         group: chartcuterie
         lock_behavior: unlockWhenFinished
         materials:

--- a/gocd/pipelines/chartcuterie.yaml
+++ b/gocd/pipelines/chartcuterie.yaml
@@ -1,0 +1,71 @@
+# More information on gocd-flavor YAML can be found here:
+# - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
+# - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
+format_version: 10
+pipelines:
+    deploy-chartcuterie:
+        environment_variables:
+            GCP_PROJECT: internal-sentry
+            GKE_CLUSTER: zdpwkxst
+            GKE_REGION: us-central1
+            GKE_CLUSTER_ZONE: b
+            GKE_BASTION_ZONE: b
+            # Read access to private repositories for the GoCD agent.
+            GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
+        group: chartcuterie
+        lock_behavior: unlockWhenFinished
+        materials:
+            chartcuterie_repo:
+                git: git@github.com:getsentry/chartcuterie.git
+                shallow_clone: true
+                branch: master
+                destination: chartcuterie
+        stages:
+            - checks:
+                  approval:
+                      type: manual
+                  fetch_materials: true
+                  jobs:
+                      checks:
+                          timeout: 1800
+                          elastic_profile_id: chartcuterie
+                          tasks:
+                              - script: |
+                                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                                    getsentry/chartcuterie \
+                                    ${GO_REVISION_CHARTCUTERIE_REPO} \
+                                    build
+                              - script: |
+                                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+                                    ${GO_REVISION_CHARTCUTERIE_REPO} \
+                                    sentryio \
+                                    "us.gcr.io/sentryio/chartcuterie"
+            - deploy:
+                  approval:
+                      type: manual
+                  fetch_materials: true
+                  jobs:
+                      deploy:
+                          timeout: 1800 # 30 mins
+                          elastic_profile_id: chartcuterie
+                          tasks:
+                              - script: |
+                                    USE_GKE_GCLOUD_AUTH_PLUGIN=True \
+                                        gcloud --project "$GCP_PROJECT" \
+                                        container clusters get-credentials "$GKE_CLUSTER" \
+                                        --zone "${GKE_REGION}-${GKE_CLUSTER_ZONE}"
+                              - script: |
+                                    tmpdir=$(mktemp -d) \
+                                    && ssh-keygen -q -t ed25519 -N '' -f "${tmpdir}/google_compute_engine" \
+                                    && gcloud compute ssh "dicd-gkehop-${GKE_CLUSTER}" \
+                                      --ssh-key-file="${tmpdir}/google_compute_engine" \
+                                      --tunnel-through-iap \
+                                      "--project=${GCP_PROJECT}" \
+                                      "--zone=${GKE_REGION}-${GKE_BASTION_ZONE}" \
+                                      -- -4 -L8888:127.0.0.1:8888 -N -q -f
+                              - script: |
+                                    /devinfra/scripts/k8s/k8sdeploy.py \
+                                    --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                                    --label-selector="service=chartcuterie" \
+                                    --image="us.gcr.io/sentryio/chartcuterie:${GO_REVISION_CHARTCUTERIE_REPO}" \
+                                    --container-name="chartcuterie"


### PR DESCRIPTION
This adds deployment configurations for GoCD, the new internal continuous deployment tool. Please refer to the [Freight Migration Guide](https://www.notion.so/sentry/Freight-Migration-Guide-2bd47bb683254077ad31e7ad625345ae) for info on how to coordinate GoCD deploys during this transitional phase.

@asottile-sentry and I are planning on using this to test out canary deploys for chartcuterie (https://github.com/getsentry/ops/pull/5787) as a PoC for getsentry canary.
