### PR TITLE
chore: Update Node.js Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM node:16-slim
+FROM node:20-slim
 
 ENV NODE_ENV=production
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        libcairo2-dev \
-        libpango1.0-dev \
-        libjpeg-dev \
-        libgif-dev \
-        librsvg2-dev \
+    build-essential \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Node.js 16 is outdated.

Seeing these errors on hybrid cloud world: `"[33mwarn[39m: Failed to resolve config while polling with error: SyntaxError: Unexpected token '??='"`. 

I'm hoping updating Node.js would potentially resolve this issue.