### PR TITLE
fix(instrumentation): Call `Sentry.init()` as early as possible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,18 @@
 #!/usr/bin/env node
 
 import * as Sentry from '@sentry/node';
+import {nodeProfilingIntegration} from '@sentry/profiling-node';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [nodeProfilingIntegration()],
+  profilesSampleRate: 1,
+  tracesSampleRate: 1,
+  _experiments: {
+    metricsAggregator: true,
+  },
+});
+
 import dotenv from 'dotenv';
 import yargs from 'yargs';
 
@@ -11,7 +23,6 @@ import {renderStream} from './renderStream';
 import {PollingConfig} from './types';
 
 dotenv.config();
-Sentry.init({dsn: process.env.SENTRY_DSN});
 
 const defaultPollingConfig: PollingConfig = {
   /**

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -2,7 +2,6 @@
 import {performance} from 'node:perf_hooks';
 
 import * as Sentry from '@sentry/node';
-import {nodeProfilingIntegration} from '@sentry/profiling-node';
 import express from 'express';
 
 import {ConfigService} from './config';
@@ -16,16 +15,6 @@ import {validateRenderData} from './validate';
 export function renderServer(config: ConfigService) {
   const app = express();
   const renderRoutes = express.Router();
-
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    integrations: [nodeProfilingIntegration()],
-    profilesSampleRate: 1,
-    tracesSampleRate: 1,
-    _experiments: {
-      metricsAggregator: true,
-    },
-  });
 
   renderRoutes.use(express.json({limit: '20mb'}));
   renderRoutes.use((req, resp) => {


### PR DESCRIPTION
Sentry.init() needs to come before all the relevant imports