### PR TITLE
fix(gocd): Adding elastic_profile_id

### DIFF
--- a/gocd/templates/pipelines/chartcuterie.libsonnet
+++ b/gocd/templates/pipelines/chartcuterie.libsonnet
@@ -21,6 +21,7 @@ function(region) {
         jobs: {
           checks: {
             timeout: 1200,
+            elastic_profile_id: 'chartcuterie',
             environment_variables: {
               GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
             },


### PR DESCRIPTION
We forgot the elastic_profile_id originally which caused GoCD to use a static agent which didn't have the necessary scripts available, causing the failures we saw.