### PR TITLE
feat(profiling) use continuous profiler instead of the span/txn based one

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -12,7 +12,7 @@ const client = Sentry.getClient();
 if (client) {
   const profilingIntegration = client.getIntegrationByName("ProfilingIntegration");
 
-  if(profilingIntegration) {
+  if (profilingIntegration) {
     // @ts-expect-error this is purposefuly not exposed by the SDK for now
     profilingIntegration._profiler.start();
   }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -4,6 +4,16 @@ import {nodeProfilingIntegration} from '@sentry/profiling-node';
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   integrations: [nodeProfilingIntegration()],
-  profilesSampleRate: 1,
   tracesSampleRate: 1,
 });
+
+const client = Sentry.getClient();
+
+if(client) {
+  const profilingIntegration = client.getIntegrationByName("ProfilingIntegration");
+
+  if(profilingIntegration) {
+    // @ts-expect-error this is purposefuly not exposed by the SDK for now
+    profilingIntegration._profiler.start();
+  }
+}

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -9,7 +9,7 @@ Sentry.init({
 
 const client = Sentry.getClient();
 
-if(client) {
+if (client) {
   const profilingIntegration = client.getIntegrationByName("ProfilingIntegration");
 
   if(profilingIntegration) {


### PR DESCRIPTION
We want to start ingesting some profiles from a production env using the new continuous profiler