### PR TITLE
ref: Use the VM to execute local config files

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as echarts from 'echarts';
+import {promises as fsPromises} from 'node:fs';
 import path from 'node:path';
 import {runInNewContext} from 'node:vm';
 
@@ -24,6 +25,14 @@ async function loadViaHttp(url: string, ac?: AbortController) {
 
   const configJavascript = await resp.text();
 
+  return evalConfigFile(configJavascript);
+}
+
+/**
+ * Loads a config file by using the vm module to execute the file cotnents as a
+ * string.
+ */
+function evalConfigFile(configJavascript: string) {
   const exports = {default: null};
   const module = {exports};
 
@@ -77,7 +86,7 @@ export class ConfigService {
    */
   async fetchConfig(deadline: number) {
     if (!this.configIsViaHttp) {
-      return require(/* webpackIgnore: true */ path.resolve(this.#uri)).default;
+      return evalConfigFile(await fsPromises.readFile(path.resolve(this.#uri), 'utf8'));
     }
 
     let config: any = null;

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,8 +1,14 @@
 import fetchMock from 'jest-fetch-mock';
+import {promises as fsPromises} from 'node:fs';
 
 fetchMock.enableMocks();
 
 import {ConfigService} from 'app/config';
+
+jest.mock('node:fs', () => ({
+  ...jest.requireActual('node:fs'),
+  promises: {readFile: jest.fn()},
+}));
 
 describe('config', () => {
   beforeEach(() => {
@@ -10,51 +16,52 @@ describe('config', () => {
   });
 
   it('can load config via files', async () => {
-    const init = jest.fn();
-    jest.mock(
-      '/myConfig',
-      () => {
-        const renderConfig = new Map();
-        renderConfig.set('fileExample', {
-          key: 'fileExample',
-          height: 200,
-          width: 100,
-          getOption: (series: any) => ({series}),
-        });
+    const configModule = `
+    var renderConfig = new Map();
+    renderConfig.set('fileExample', {
+      key: 'example',
+      height: 200,
+      width: 100,
+      getOption: series => ({series}),
+    });
 
-        return {default: {renderConfig, init, version: 'abc'}};
-      },
-      {virtual: true}
-    );
+    module.exports = {renderConfig, version: 'abc'};`;
+
+    jest.mocked(fsPromises.readFile).mockResolvedValue(Buffer.from(configModule));
 
     const config = new ConfigService('/myConfig');
     await config.resolveEnsured();
 
+    expect(fsPromises.readFile).toHaveBeenCalledWith('/myConfig', 'utf8');
     expect(config.getConfig('fileExample')?.height).toEqual(200);
-    expect(init).toHaveBeenCalledTimes(1);
   });
 
   it('does not require init', async () => {
-    jest.mock(
-      '/myConfig',
-      () => {
-        const renderConfig = new Map();
-        renderConfig.set('fileExample', {
-          key: 'fileExample',
-          height: 200,
-          width: 100,
-          getOption: (series: any) => ({series}),
-        });
+    const configModule = `
+    var renderConfig = new Map();
+    renderConfig.set('example', {
+      key: 'example',
+      height: 200,
+      width: 100,
+      getOption: series => ({series}),
+    });
 
-        return {default: {renderConfig, version: 'abc'}};
-      },
-      {virtual: true}
-    );
+    module.exports = {
+      renderConfig,
+      version: 'abc',
+      init: _ => console.log('init called')
+    };`;
+
+    const consoleSpy = jest.spyOn(console, 'log');
+    consoleSpy.mockImplementation(() => {});
+
+    jest.mocked(fsPromises.readFile).mockResolvedValue(Buffer.from(configModule));
 
     const config = new ConfigService('/myConfig');
     await config.resolveEnsured();
 
-    expect(config.getConfig('fileExample')?.height).toEqual(200);
+    expect(config.getConfig('example')?.height).toEqual(200);
+    expect(consoleSpy).toHaveBeenCalledWith('init called');
   });
 
   it('can load config via http', async () => {
@@ -62,7 +69,7 @@ describe('config', () => {
     var renderConfig = new Map();
     renderConfig.set('example', {
       key: 'example',
-      height: 100,
+      height: 200,
       width: 100,
       getOption: series => ({series}),
     });
@@ -75,6 +82,6 @@ describe('config', () => {
     await config.resolveEnsured();
 
     expect(fetchMock.mock.calls[0][0]).toEqual('https://example.com/myConfig.js');
-    expect(config.getConfig('example')?.height).toEqual(100);
+    expect(config.getConfig('example')?.height).toEqual(200);
   });
 });


### PR DESCRIPTION
This makes config file loading consistent between using the http config resolver and passing a local file path to load the config.

Consistency is important here for us since in Sentry we have chartucterie acceptance tests, which are there to help us catch changes made to Sentry's javascript app that may break chartucterie. However they are run with chartucterie having loaded the config using a file path and not HTTP, which differs from happens in production, where we resolve the config via HTTP and execute it in a vm context.

By making these consistent we catch errors that happen loading the config in the vm contextchartucterie VM.