### PR TITLE
feat(devservices): Add chartcuterie config

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,0 +1,40 @@
+# Ignored by docker compose, used by devservices
+x-sentry-service-config:
+  version: 0.1
+  service_name: chartcuterie
+  dependencies:
+    chartcuterie:
+      description: Chartcuterie offers fresh slices and dices of absolutely delectable graphs.
+  modes:
+    default: [chartcuterie]
+
+services:
+  chartcuterie:
+    image: 'us-central1-docker.pkg.dev/sentryio/chartcuterie/image:latest'
+    environment:
+      CHARTCUTERIE_CONFIG: /etc/chartcuterie/config.js
+      CHARTCUTERIE_CONFIG_POLLING: true
+    volumes:
+      - $CHARTCUTERIE_CONFIG_PATH:/etc/chartcuterie
+    ports:
+      - 127.0.0.1:7901:9090
+    networks:
+      - devservices
+    extra_hosts:
+      host.docker.internal: host-gateway
+    labels:
+      - 'orchestrator=devservices'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'docker exec sentry_chartcuterie python3 -c "import urllib.request; urllib.request.urlopen(\"http://127.0.0.1:9090/api/chartcuterie/healthcheck/live\", timeout=5)"',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+
+networks:
+  devservices:
+    name: devservices
+    external: true


### PR DESCRIPTION
This PR adds the devservices config for running chartcuterie in containerized mode. This is a part of the effort to define service configs in the service repos themselves, where service configs can later be reused in future services. What this means is that using devservices to bring up sentry will import this config definition if chartcuterie should be brought up.

See snuba for example here: https://github.com/getsentry/sentry/blob/master/devservices/config.yml#L6