### PR TITLE
ref(gocd): Cutting over to check_cloudbuild.py

### DIFF
--- a/gocd/templates/bash/check-cloudbuild.sh
+++ b/gocd/templates/bash/check-cloudbuild.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+/devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
+  sentryio \
+  chartcuterie \
+  chartcuterie-branch-builder \
   "${GO_REVISION_CHARTCUTERIE_REPO}" \
-  "sentryio" \
-  "us-central1-docker.pkg.dev/sentryio/chartcuterie/image"
+  master


### PR DESCRIPTION
Cutting over to the new check_cloudbuild script that doesn't rely on images anymore and instead relies on repo_name, trigger_name, sha, and branch_name.
https://linear.app/getsentry/issue/DI-631/update-getsentrychartcuterie-to-use-new-script