### PR TITLE
feat: Send chartcuterie logs to Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "^9.8.0",
-    "@sentry/profiling-node": "^9.8.0",
+    "@sentry/node": "^9.15.0",
+    "@sentry/profiling-node": "^9.15.0",
     "canvas": "^2.11.2",
     "dotenv": "^8.2.0",
     "echarts": "5.4.0",

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -7,4 +7,7 @@ Sentry.init({
   tracesSampleRate: 1,
   profileLifecycle: 'trace',
   profileSessionSampleRate: 1,
+  _experiments: {
+    enableLogs: true,
+  },
 });

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,10 +1,14 @@
+import * as Sentry from '@sentry/node';
 import {createLogger, format, transports} from 'winston';
+import Transport from 'winston-transport';
+
+const SentryWinstonTransport = Sentry.createSentryWinstonTransport(Transport);
 
 export const logger = createLogger({
   level: 'info',
   format: format.json(),
   transports: [
-    // TODO: What transports need to go into here in production?
+    new SentryWinstonTransport(),
   ],
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,10 +1000,10 @@
   dependencies:
     "@opentelemetry/core" "^1.1.0"
 
-"@prisma/instrumentation@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-6.5.0.tgz#ce6c160365dfccbe0f4e7c57a4afc4f946fee562"
-  integrity sha512-morJDtFRoAp5d/KENEm+K6Y3PQcn5bCvpJ5a9y3V3DNMrNy/ZSn2zulPGj+ld+Xj2UYVoaMJ8DpBX/o6iF6OiA==
+"@prisma/instrumentation@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-6.6.0.tgz#5b73164c722bcfcd29c43cb883b4735143b65eb2"
+  integrity sha512-M/a6njz3hbf2oucwdbjNKrSMLuyMCwgDrmTtkF1pm4Nm7CU45J/Hd6lauF2CDACTUYzu3ymcV7P0ZAhIoj6WRw==
   dependencies:
     "@opentelemetry/instrumentation" "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
 
@@ -1015,15 +1015,15 @@
     detect-libc "^2.0.3"
     node-abi "^3.73.0"
 
-"@sentry/core@9.8.0":
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.8.0.tgz#31f04746cff67ba004eb478f2dd144eadfa2d9cf"
-  integrity sha512-EnN2yLWCbWjooWBPzwlXdZoJG/Bqn3ymbuXX++DUJuBGjSmtixQeTf/hKeVzj4zbib3BbbYsNBasRVjq8Rk5ng==
+"@sentry/core@9.15.0":
+  version "9.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.15.0.tgz#590f16a15596ce01db49d9d80b31cb18048ca9a4"
+  integrity sha512-lBmo3bzzaYUesdzc2H5K3fajfXyUNuj5koqyFoCAI8rnt9CBl7SUc/P07+E5eipF8mxgiU3QtkI7ALzRQN8pqQ==
 
-"@sentry/node@9.8.0", "@sentry/node@^9.8.0":
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.8.0.tgz#0398e491a49008fefef86af587272d6810be29f6"
-  integrity sha512-whkz/TBkEhwqdm/onukqMLEVjFW0j9OqEx5GkaqqRPpiX8Q3nZV80C1KV6J7phV0asMduHftBXQLKMmJs5ZODw==
+"@sentry/node@9.15.0", "@sentry/node@^9.15.0":
+  version "9.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.15.0.tgz#f43954ed8ccdc1cb7d5c315b7d481c5f46300885"
+  integrity sha512-K0LdJxIzYbbsbiT+1tKgNq6MUHuDs2DggBDcFEp3T+yXVJYN1AyalUli06Kmxq8yvou6hgLwWL4gjIcB1IQySA==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.30.1"
@@ -1055,26 +1055,26 @@
     "@opentelemetry/resources" "^1.30.1"
     "@opentelemetry/sdk-trace-base" "^1.30.1"
     "@opentelemetry/semantic-conventions" "^1.30.0"
-    "@prisma/instrumentation" "6.5.0"
-    "@sentry/core" "9.8.0"
-    "@sentry/opentelemetry" "9.8.0"
+    "@prisma/instrumentation" "6.6.0"
+    "@sentry/core" "9.15.0"
+    "@sentry/opentelemetry" "9.15.0"
     import-in-the-middle "^1.13.0"
 
-"@sentry/opentelemetry@9.8.0":
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.8.0.tgz#a02e91c2e6bf668c47babe4ab0a2fa2f6d86d644"
-  integrity sha512-7EWfLC5HOBYH23FxZJNK8BuQ3MCWTf/1cfH3UH773653Z/z4V49N4Xo4Zcx+y7BNVt9g6Hy23Jn0AsFAk2oisQ==
+"@sentry/opentelemetry@9.15.0":
+  version "9.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.15.0.tgz#1888c8a08e69a49345d6a161a6dbc04fe6c7744f"
+  integrity sha512-gGOzgSxbuh4B4SlEonL1LFsazmeqL/fn5CIQqRG0UWWxdt6TKAMlj0ThIlGF3jSHW2eXdpvs+4E73uFEaHIqfg==
   dependencies:
-    "@sentry/core" "9.8.0"
+    "@sentry/core" "9.15.0"
 
-"@sentry/profiling-node@^9.8.0":
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-9.8.0.tgz#67c19de3a8ec11f36654fcbbf798a09381ac17bb"
-  integrity sha512-J1CfJ33IKMzsR0J2Jyfegl1d/Ghwq+MhYXrL/GBOmOaet5wXU1hr85hQGfmfkFiy0gTfSZb5sZOjJfHhK0goUA==
+"@sentry/profiling-node@^9.15.0":
+  version "9.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-9.15.0.tgz#04c7588b8f805f521178e2ef859a482ea21b1e80"
+  integrity sha512-I5lU5XNYOTeULAUgeZg9Un+nKmwkDKCQ9R6B+RUkT73Lz+xI6miriEfPcMXbeOcTwU6XygKHpcm+0Ksi80QJYA==
   dependencies:
     "@sentry-internal/node-cpu-profiler" "^2.0.0"
-    "@sentry/core" "9.8.0"
-    "@sentry/node" "9.8.0"
+    "@sentry/core" "9.15.0"
+    "@sentry/node" "9.15.0"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
Production logs from charcuterie (with the correct trace) should now go into Sentry.