### PR TITLE
chore: Swap back to stable `@sentry/node` SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "^9.36.0-alpha.2",
-    "@sentry/profiling-node": "^9.36.0-alpha.2",
+    "@sentry/node": "^9.38.0",
+    "@sentry/profiling-node": "^9.38.0",
     "canvas": "^2.11.2",
     "dotenv": "^8.2.0",
     "echarts": "5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,10 +960,10 @@
   dependencies:
     "@opentelemetry/core" "^1.1.0"
 
-"@prisma/instrumentation@6.10.1":
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-6.10.1.tgz#805f0dcdc29638009f0da709828396894815c893"
-  integrity sha512-JC8qzgEDuFKjuBsqrZvXHINUb12psnE6Qy3q5p2MBhalC1KW1MBBUwuonx6iS5TCfCdtNslHft8uc2r+EdLWWg==
+"@prisma/instrumentation@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-6.11.1.tgz#db3c40dbf325cf7a816504b8bc009ca3d4734c2f"
+  integrity sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==
   dependencies:
     "@opentelemetry/instrumentation" "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
 
@@ -975,24 +975,24 @@
     detect-libc "^2.0.3"
     node-abi "^3.73.0"
 
-"@sentry/core@9.36.0-alpha.2":
-  version "9.36.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.36.0-alpha.2.tgz#12f0b7ae8c3e569b009d2621938e9cab3bcd6d87"
-  integrity sha512-jUekSm+TZ1OhlzmK32oq2HxR90neEyIjNsCNlImKAhHkpUbjW0hHdup4G9aKhzipq08CKyHgD3H7z0JqRztBew==
+"@sentry/core@9.38.0":
+  version "9.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.38.0.tgz#8055bb856b1f0fc799040cbd34d1f6c6b3883ad3"
+  integrity sha512-dUwSv1VXDfsrcY69a/cgZNDsFal6iYOf0C4T+/ylpmgYp5SVe3vQK+2FLXUMuvgnOf+kHO6IeW0RhnhSyUflmA==
 
-"@sentry/node-core@9.36.0-alpha.2":
-  version "9.36.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-9.36.0-alpha.2.tgz#f250f61da8bc8de5731b828b214867cc563afbc1"
-  integrity sha512-e4uWOW3DvJ1y1K7Huh9zs7DRTe0eWxvtobewE2cBzAq17dqN4JYzMqNir5zI+Cdx7q5X01i3wtUXbfqrqC7Drg==
+"@sentry/node-core@9.38.0":
+  version "9.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-9.38.0.tgz#d941e23537423f8eb851d41237c1cada6d0c7aac"
+  integrity sha512-G0JmsntsvALoqS9iLTi4Jn1DcQB7gw9PY1Fmkdcdcf7i4EJEdRDX0tiD9ssDrcjgzzFPnm0PCrSAkIfTtd3Zyg==
   dependencies:
-    "@sentry/core" "9.36.0-alpha.2"
-    "@sentry/opentelemetry" "9.36.0-alpha.2"
+    "@sentry/core" "9.38.0"
+    "@sentry/opentelemetry" "9.38.0"
     import-in-the-middle "^1.14.2"
 
-"@sentry/node@9.36.0-alpha.2", "@sentry/node@^9.36.0-alpha.2":
-  version "9.36.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.36.0-alpha.2.tgz#b228679ec13f2b40248204ffdaf8220dc360395e"
-  integrity sha512-cW0d8xlpg+gF61PUMh5Vb7K8JpG7Nfff6RggqYfn1KTDaCGZZ+PjwwLqUs+2pqu3eelSVoZ/Y89pupfsddLgYA==
+"@sentry/node@9.38.0", "@sentry/node@^9.38.0":
+  version "9.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-9.38.0.tgz#b5effcff1e8278027d3e4b534595f06237bd1595"
+  integrity sha512-OhfRTge6hncSehrTBHpnz5R66OWRd8WMKn6ZoS0nwBmTfREjPkNRfOADIUqEElfyuaNj+gWsqTM1/E915pnZew==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/context-async-hooks" "^1.30.1"
@@ -1023,28 +1023,28 @@
     "@opentelemetry/resources" "^1.30.1"
     "@opentelemetry/sdk-trace-base" "^1.30.1"
     "@opentelemetry/semantic-conventions" "^1.34.0"
-    "@prisma/instrumentation" "6.10.1"
-    "@sentry/core" "9.36.0-alpha.2"
-    "@sentry/node-core" "9.36.0-alpha.2"
-    "@sentry/opentelemetry" "9.36.0-alpha.2"
+    "@prisma/instrumentation" "6.11.1"
+    "@sentry/core" "9.38.0"
+    "@sentry/node-core" "9.38.0"
+    "@sentry/opentelemetry" "9.38.0"
     import-in-the-middle "^1.14.2"
     minimatch "^9.0.0"
 
-"@sentry/opentelemetry@9.36.0-alpha.2":
-  version "9.36.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.36.0-alpha.2.tgz#f958965001063165ed358d6f2a639d1ea4d2fcce"
-  integrity sha512-XWaX97Yv0mTdKFJhrtpbqpHex8TMhWeIaa2fqG/EPDAw3TbQVkSREbYQm9u6/a/B5w/RUxZZLr621b/W/N1qeA==
+"@sentry/opentelemetry@9.38.0":
+  version "9.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-9.38.0.tgz#494d5e79c17764e5ee603426b648f8089f95b616"
+  integrity sha512-Oa0kk4EiBMwCvHS5ZI50M/SMNfGM9ztsmedFEfpS+mZz8y9C5Artd0ukGK4OAYcSBggNVQkhmmhWbwpNnRNQiw==
   dependencies:
-    "@sentry/core" "9.36.0-alpha.2"
+    "@sentry/core" "9.38.0"
 
-"@sentry/profiling-node@^9.36.0-alpha.2":
-  version "9.36.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-9.36.0-alpha.2.tgz#50ce1ef7e1e5876a37070793518f0d00eebbd6d4"
-  integrity sha512-aXU+GYIwJv+6+C4o5Yw9eWE7aulqOl194BEZzLNvAgK02sympoe+32o+L9YRQ4SiJ3SWzGDe/AHwUD5MkuyLPQ==
+"@sentry/profiling-node@^9.38.0":
+  version "9.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-9.38.0.tgz#a02d74a6de4bf4dea5d5d8059f56bae1cfb8e1c3"
+  integrity sha512-ezdcQt+n+NLmOAJgCaBDGW7qdxn7zgrefuv3t5l0JKr94KdX6MnpvKFNYFaoccPtUVgbBBVWYRpEPTqbkG52cQ==
   dependencies:
     "@sentry-internal/node-cpu-profiler" "^2.2.0"
-    "@sentry/core" "9.36.0-alpha.2"
-    "@sentry/node" "9.36.0-alpha.2"
+    "@sentry/core" "9.38.0"
+    "@sentry/node" "9.38.0"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
We previously tested an alpha version of our SDK for dogfooding purposes, the testing period has concluded and we can now swap back to a stable release.