### PR TITLE
ref(gocd): gocd-jsonnet 3.0.4

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.3"
+      "version": "v3.0.4"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "11c0c766fc66ef7d1b100f8c83b0ba56612bab2e",
-      "sum": "DwMwLzsG4k4fqJWibFgTk71p93ivdFupCpftwDbK5xU="
+      "version": "7a25c44956933a57b5ca03beb3b70c470724c2c8",
+      "sum": "0S+eGE0WHdxJxKS/Bdga+NB+cB+ZBwF4LoehKv0azXc="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bumps gocd-jsonnet from v3.0.3 to v3.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)