### PR TITLE
fix(explore): Allow ECharts to create more `canvas` elements

### DIFF
--- a/smoketest.js
+++ b/smoketest.js
@@ -31,7 +31,7 @@ const result = renderSync({
 const {buffer} = result;
 result.dispose();
 
-const EXPECTED_SHA256 = '2616947b26199985b53250044725868a530ee2e2328ed2380825a2cbd71c37f9';
+const EXPECTED_SHA256 = '7f9c9aac774389a04548e6c3a98afbf6b31be4f03fdc703933ae4da669180371';
 const actual = crypto.createHash('sha256').update(buffer).digest('hex');
 if (actual !== EXPECTED_SHA256) {
   throw new Error(`smoke test failed: output hash ${actual} !== expected ${EXPECTED_SHA256}`);

--- a/src/render.ts
+++ b/src/render.ts
@@ -6,6 +6,16 @@ import {disabledOptions, registerCanvasFonts} from './utils';
 
 registerCanvasFonts();
 
+// ECharts renders some series (e.g., heatmaps) on a separate canvas layer. In a
+// browser it creates those layers via `document.createElement`, but in Node it
+// has no way to do so and `createCanvas` returns `false`, blowing up when it
+// tries to size the layer. Add the API for `canvas` creation.
+echarts.setPlatformAPI({
+  // ECharts always resizes the canvas after creating it, so these dimensions
+  // are just placeholders.
+  createCanvas: () => createCanvas(1, 1) as any,
+});
+
 /**
  * Renders a single chart
  */


### PR DESCRIPTION
Some ECharts visualizations, like Heat Maps actually create _more_ `canvas` elements during the rendering process. This crashes completely without defining the API. Setting the `createCanvas` method allows ECharts to work correctly.

On Linux, this produces a _very_ small visual change in the rendering for the smoke test:

**Before:**
<img width="100" height="100" alt="smoke" src="https://github.com/user-attachments/assets/d39b2ace-6009-4604-b7d8-278c4db76ad9" />


**After:**
<img width="100" height="100" alt="smoke" src="https://github.com/user-attachments/assets/c86246f1-b586-4c5e-8d6c-ba7f444422e5" />

Claude is convinced (and I'm inclined to agree) that this is because of ECharts `measureText`. This function is called to try and calculate font sizes for positioning and overlap calculation. `measureText` calls `createCanvas` under-the-hood for measurement, and now that we're providing an implementation, it actually does it! Before it was just _estimating_ the width, but now it's using `_ctx.measureText(text)`, so results should be better overall.