### PR TITLE
feat(telemetry): add chart style and config version span attributes

### DIFF
--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -43,6 +43,11 @@ export function renderServer(config: ConfigService) {
       style = {...style, width: renderData.width, height: renderData.height};
     }
 
+    Sentry.getActiveSpan()?.setAttributes({
+      'chart.style': renderData.style,
+      'chart.config_version': config.version.toString(),
+    });
+
     let render: ReturnType<typeof renderSync> | undefined;
     try {
       render = renderSync(style, renderData.data);

--- a/src/renderServer.ts
+++ b/src/renderServer.ts
@@ -45,7 +45,7 @@ export function renderServer(config: ConfigService) {
 
     Sentry.getActiveSpan()?.setAttributes({
       'chart.style': renderData.style,
-      'chart.config_version': config.version.toString(),
+      'chart.config_version': config.version?.toString(),
     });
 
     let render: ReturnType<typeof renderSync> | undefined;


### PR DESCRIPTION
## Summary

Adds span attributes to the auto-instrumented `/render` transaction so renders can be filtered and aggregated in Sentry:

- `chart.style` — the requested style config key
- `chart.config_version` — the loaded config version (`.toString()` since `config.version` is `string | symbol`)

These attach to the span the Express integration already creates for `/render`, so no new span/transaction is introduced.

## Test plan

- [x] `yarn tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)