### PR TITLE
fix: Disable ECharts progressive rendering

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,5 +21,8 @@ export const disabledOptions: EChartsOption = {
   animation: false,
   toolbox: undefined,
   tooltip: undefined,
-  progressive: false,
+  // Disable progressive rendering, it never makes sense in a server rendered
+  // context.
+  // https://echarts.apache.org/en/option.html#series-heatmap.progressive
+  progressive: 0,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,4 +21,5 @@ export const disabledOptions: EChartsOption = {
   animation: false,
   toolbox: undefined,
   tooltip: undefined,
+  progressive: false,
 };


### PR DESCRIPTION
ECharts will progressively render charts if the number of data points exceeds 3,000. We've never hit this limit before, but Heat Map widgets hit this limit _easily_. When ECharts turn on progressive rendering server-side, it renders an incomplete chart, since the rendering is scheduled to the next tick, and the buffer is flushed before that happens.

Progressive rendering _never_ makes sense on the backend, so I'm turning it off wholesale in Chartcuterie rather than through the chart configs.

**Before:**
<img width="1200" height="400" alt="before" src="https://github.com/user-attachments/assets/3c222965-7f06-4309-91f8-3d03f83d792e" />

**After:**
<img width="1200" height="400" alt="after" src="https://github.com/user-attachments/assets/17364839-a419-4546-8dd2-519aead0ec5e" />
