### PR TITLE
fix(render): Disable ECharts progressive rendering

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import {createCanvas} from 'canvas';
 import * as echarts from 'echarts';
-import type {EChartsOption} from 'echarts';
+import type {SeriesOption} from 'echarts';
 
 import {RenderDescriptor} from './types';
 import {disabledOptions, registerCanvasFonts} from './utils';
@@ -31,11 +31,16 @@ export function renderSync(style: RenderDescriptor, data: any) {
     width: style.width,
     height: style.height,
   });
-  chart.setOption({
-    ...options,
-    series: disableProgressive(options.series as EChartsOption['series']),
-    ...disabledOptions,
-  });
+
+  // `series` may be a single series or an array of them.
+  let series = options.series as SeriesOption | SeriesOption[] | undefined;
+  if (Array.isArray(series)) {
+    series = series.map(disableProgressive);
+  } else if (series) {
+    series = disableProgressive(series);
+  }
+
+  chart.setOption({...options, series, ...disabledOptions});
 
   return {
     buffer: canvas.toBuffer('image/png'),
@@ -48,12 +53,6 @@ export function renderSync(style: RenderDescriptor, data: any) {
 // series across multiple frames, which means `canvas.toBuffer` can snapshot a
 // partially-drawn chart. It never makes sense in a server-rendered context.
 // https://echarts.apache.org/en/option.html#series-heatmap.progressive
-function disableProgressive(series: EChartsOption['series']): EChartsOption['series'] {
-  if (Array.isArray(series)) {
-    return series.map(s => ({...s, progressive: 0}));
-  }
-  if (series) {
-    return {...series, progressive: 0};
-  }
-  return series;
+function disableProgressive(series: SeriesOption): SeriesOption {
+  return {...series, progressive: 0};
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,6 @@
 import {createCanvas} from 'canvas';
 import * as echarts from 'echarts';
+import type {EChartsOption} from 'echarts';
 
 import {RenderDescriptor} from './types';
 import {disabledOptions, registerCanvasFonts} from './utils';
@@ -30,10 +31,29 @@ export function renderSync(style: RenderDescriptor, data: any) {
     width: style.width,
     height: style.height,
   });
-  chart.setOption({...options, ...disabledOptions});
+  chart.setOption({
+    ...options,
+    series: disableProgressive(options.series as EChartsOption['series']),
+    ...disabledOptions,
+  });
 
   return {
     buffer: canvas.toBuffer('image/png'),
     dispose: () => chart.dispose(),
   };
+}
+
+// `progressive` is a per-series option in ECharts; there is no top-level
+// equivalent, so it must be set on each series. Progressive rendering splits a
+// series across multiple frames, which means `canvas.toBuffer` can snapshot a
+// partially-drawn chart. It never makes sense in a server-rendered context.
+// https://echarts.apache.org/en/option.html#series-heatmap.progressive
+function disableProgressive(series: EChartsOption['series']): EChartsOption['series'] {
+  if (Array.isArray(series)) {
+    return series.map(s => ({...s, progressive: 0}));
+  }
+  if (series) {
+    return {...series, progressive: 0};
+  }
+  return series;
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import {createCanvas} from 'canvas';
-import * as echarts from 'echarts';
 import type {SeriesOption} from 'echarts';
+import * as echarts from 'echarts';
 
 import {RenderDescriptor} from './types';
 import {disabledOptions, registerCanvasFonts} from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,8 +21,4 @@ export const disabledOptions: EChartsOption = {
   animation: false,
   toolbox: undefined,
   tooltip: undefined,
-  // Disable progressive rendering, it never makes sense in a server rendered
-  // context.
-  // https://echarts.apache.org/en/option.html#series-heatmap.progressive
-  progressive: 0,
 };


### PR DESCRIPTION
Properly disables ECharts progressive rendering for server-rendered charts, and reverts the earlier no-op attempt.

#234 added `progressive: 0` to the top-level `disabledOptions` object spread into `chart.setOption(...)`. That is a no-op: ECharts only reads `progressive` as a **series-level** option, whoopsie. Instead, we need to disable progressive rendering _per series_. I still feel that doing it _here_ is correct, we don't want to leave that to the chart configs.

Closes DAIN-1740