### PR TITLE
fix(render): Disable ECharts progressive rendering with threshold

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -52,7 +52,10 @@ export function renderSync(style: RenderDescriptor, data: any) {
 // equivalent, so it must be set on each series. Progressive rendering splits a
 // series across multiple frames, which means `canvas.toBuffer` can snapshot a
 // partially-drawn chart. It never makes sense in a server-rendered context.
+// `progressiveThreshold` is the maximum number of data points before progressive rendering
+// is enabled. We don't want to enable progressive rendering AT ALL so we'll need to set
+// this to Infinity to disable it entirely.
 // https://echarts.apache.org/en/option.html#series-heatmap.progressive
 function disableProgressive(series: SeriesOption): SeriesOption {
-  return {...series, progressive: 0};
+  return {...series, progressive: 0, progressiveThreshold: Infinity};
 }


### PR DESCRIPTION
In addition to the `progressive` option being disabled, we're also raising the `progressiveThreshold` to be Infinity! in the [docs](https://echarts.apache.org/en/option.html#series-heatmap.progressive) it says that progressive rendering is automatically enabled when the number of data points exceeds the threshold. The default threshold is 3000 and heat maps can easily exceed that; setting the threshold to Infinity ensures that progressive rendering is never automatically turned on (or so we hope 🤞) 