### PR TITLE
fix(render): disable return before full canvas paint

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -15,6 +15,14 @@ echarts.setPlatformAPI({
   // ECharts always resizes the canvas after creating it, so these dimensions
   // are just placeholders.
   createCanvas: () => createCanvas(1, 1) as any,
+  // WARNING: SUPER HACKS 😭
+  // Code for context: https://github.com/apache/echarts/blob/5b0f1fd21bc25bcfdb5845029a6ba3a77a4355af/src/core/echarts.ts#L662-L703
+  // Echarts defaults to waiting 15ms per layer to paint but obviously
+  // charts with many data points (e.g. heatmaps) will take longer than that.
+  // Setting this to 0 makes ECharts ignore that 15ms budget and paint the
+  // chart fully; this means the code solely relies on the canvas paint to be finished
+  // before returning the rendered chart. This fixes the issue of the chart rendering partially.
+  getTime: () => 0,
 });
 
 /**
@@ -57,5 +65,5 @@ export function renderSync(style: RenderDescriptor, data: any) {
 // this to Infinity to disable it entirely.
 // https://echarts.apache.org/en/option.html#series-heatmap.progressive
 function disableProgressive(series: SeriesOption): SeriesOption {
-  return {...series, progressive: 0, progressiveThreshold: Infinity};
+  return {...series, progressive: 0, animation: false};
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -17,6 +17,7 @@ echarts.setPlatformAPI({
   createCanvas: () => createCanvas(1, 1) as any,
   // WARNING: SUPER HACKS 😭
   // Code for context: https://github.com/apache/echarts/blob/5b0f1fd21bc25bcfdb5845029a6ba3a77a4355af/src/core/echarts.ts#L662-L703
+  // PLZ NOTE: this hack is not documented in ECharts docs so please check the code link above for more details!
   // Echarts defaults to waiting 15ms per layer to paint but obviously
   // charts with many data points (e.g. heatmaps) will take longer than that.
   // Setting this to 0 makes ECharts ignore that 15ms budget and paint the

--- a/src/render.ts
+++ b/src/render.ts
@@ -16,8 +16,9 @@ echarts.setPlatformAPI({
   // are just placeholders.
   createCanvas: () => createCanvas(1, 1) as any,
   // WARNING: SUPER HACKS 😭
-  // Code for context: https://github.com/apache/echarts/blob/5b0f1fd21bc25bcfdb5845029a6ba3a77a4355af/src/core/echarts.ts#L662-L703
-  // PLZ NOTE: this hack is not documented in ECharts docs so please check the code link above for more details!
+  // Code for context: https://github.com/apache/echarts/blob/master/src/core/echarts.ts#L662-L703
+  // Commit where this feature was added: https://github.com/apache/echarts-website/commit/8e897fa1e58b30db1dae85a1e9060bdbc0f61b0c#diff-8f31957f9bb06adae78b3a13c71455fa2dac55acba01411459aeffa427da8bb5
+  // PLZ NOTE: this is not documented in ECharts docs so please check the code links above for more details!
   // Echarts defaults to waiting 15ms per layer to paint but obviously
   // charts with many data points (e.g. heatmaps) will take longer than that.
   // Setting this to 0 makes ECharts ignore that 15ms budget and paint the


### PR DESCRIPTION
using some undocumented e-charts hack that will basically invalidate the paint timer so that the canvas returns only when the full chart is painted and not just after the timer goes off. We were getting this error `TypeError: Cannot read properties of null (reading 'layerStack')` that seemed to be thrown because of the timeout.

Some notes about this `getTime()` api option is that it was added around 2 months ago so seems fairly recent but doesn't seem like it was added to fix a bug. My gut says it will probably stay but here's the links to those commits and PRs anyways:
- [commit](https://github.com/apache/echarts-website/commit/8e897fa1e58b30db1dae85a1e9060bdbc0f61b0c#diff-8f31957f9bb06adae78b3a13c71455fa2dac55acba01411459aeffa427da8bb5) it was added in the Platform type
- [PR](https://github.com/apache/echarts/pull/21430) where the functionality is being used in the code
- [specific commit](https://github.com/apache/echarts/commit/91a60fc763e27229aba00eaa23bc0a58a1501e8d#diff-f375651f2fb596fb2eada00e8074449ece7c723a2fbd23cb1fd647a06fc7f9d2) where functionality was added 

Done with claude's help so feel free to suggest other solutions