### PR TITLE
Add support for materialized-ops workflow

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -2,8 +2,15 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
+IMAGE="us-central1-docker.pkg.dev/sentryio/chartcuterie/image:${GO_REVISION_CHARTCUTERIE_REPO}"
+
 /devinfra/scripts/get-cluster-credentials \
   && k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
-  --image="us-central1-docker.pkg.dev/sentryio/chartcuterie/image:${GO_REVISION_CHARTCUTERIE_REPO}" \
-  --container-name="chartcuterie"
+  --image="${IMAGE}" \
+  --container-name="chartcuterie" \
+  && materialized-ops-set-image \
+  --service="chartcuterie" \
+  --label-selector="${LABEL_SELECTOR}" \
+  --container-name="chartcuterie" \
+  --image="${IMAGE}"


### PR DESCRIPTION
Adds support for writing git commits to `materialized-ops` during its code deployment pipeline. 

Re: https://github.com/getsentry/devinfra-deployment-service/pull/907