### PR TITLE
chore: Update @sentry/node to 11.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "11.0.0-alpha.0",
-    "@sentry/profiling-node": "11.0.0-alpha.0",
+    "@sentry/node": "11.0.0-alpha.1",
+    "@sentry/profiling-node": "11.0.0-alpha.1",
     "canvas": "^3.2.0",
     "dotenv": "^8.2.0",
     "echarts": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,14 +911,14 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sentry/bundler-plugins@11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.0.tgz#d7863fc89e445105cc479e577f50bca4c6a87a98"
-  integrity sha512-uLxHj0Z9fWDouq3LT4aAxukkUrz4nCYhOdW73IMziAYLFdhf1wJSv3K8ysjZLWtUng+dQ+J2admH7FVYCcf2xg==
+"@sentry/bundler-plugins@11.0.0-alpha.1":
+  version "11.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.1.tgz#829f8d9343fe9c8bcd0286e575f98b6868a120d4"
+  integrity sha512-vFYrP4a2tKPkkFmuxg2c45XqhNnn07olYwP7blFLqD4QMd7blfvB0WnC0xpmke4CUYMl+ELhWbt8KgfyiV/qLg==
   dependencies:
     "@babel/core" "^7.18.5"
     "@sentry/cli" "^2.58.6"
-    "@sentry/core" "11.0.0-alpha.0"
+    "@sentry/core" "11.0.0-alpha.1"
     dotenv "^17.4.2"
     find-up "^5.0.0"
     glob "^13.0.6"
@@ -985,17 +985,17 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
-"@sentry/conventions@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
-  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+"@sentry/conventions@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.19.0.tgz#da81dd1b8c4f2f42aca2d74251a07ff9f8718e42"
+  integrity sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==
 
-"@sentry/core@11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-11.0.0-alpha.0.tgz#1db215c869b306e457b36b5d63173f02b0896afd"
-  integrity sha512-YAwpmevzT3ghURwdLFDOFN74rZXE9VYYsgc+wsk5j8TQ6Nd+CLO2LvQvQbzxUmVJa6pN04z2oqWg+TWMpfH9QA==
+"@sentry/core@11.0.0-alpha.1":
+  version "11.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-11.0.0-alpha.1.tgz#8a7eaec19a33088e6658f0f49b1a076a5271b1d3"
+  integrity sha512-KIiN6A7QltDlPZ+OJAOfDpzfxGBUsubJoLOKV1T1pj/9KWdfQlb6V0iCPPON+SwqHTWC8YifdenmC0J5jq5BCA==
   dependencies:
-    "@sentry/conventions" "^0.16.0"
+    "@sentry/conventions" "^0.19.0"
 
 "@sentry/node-cpu-profiler@^2.4.3":
   version "2.4.3"
@@ -1005,43 +1005,43 @@
     detect-libc "^2.0.3"
     node-abi "^3.73.0"
 
-"@sentry/node@11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-11.0.0-alpha.0.tgz#9549153ee5f0724411854c62703cf15b325b06db"
-  integrity sha512-2KvlPz37RADpyvCstSJ/y4zIqb0+mVnZNtOejcAFDFoEm4tf82nW4xz0zXUMX3/0UgzWkMYMaB9vnlyss3QNXQ==
+"@sentry/node@11.0.0-alpha.1":
+  version "11.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-11.0.0-alpha.1.tgz#b77ed12fac04828338ed7ed422420a795765d30a"
+  integrity sha512-fJYi66rT5WfRfRQkIqchwj5hGobhcEJw6MGfTq3dR4xh9Ksk+hLADz+U4zu53ZuV0NXnGTHbOLWzlJ8J+zjhKA==
   dependencies:
     "@opentelemetry/api" "^1.9.1"
-    "@sentry/bundler-plugins" "11.0.0-alpha.0"
-    "@sentry/conventions" "^0.16.0"
-    "@sentry/core" "11.0.0-alpha.0"
-    "@sentry/opentelemetry" "11.0.0-alpha.0"
-    "@sentry/server-utils" "11.0.0-alpha.0"
+    "@sentry/bundler-plugins" "11.0.0-alpha.1"
+    "@sentry/conventions" "^0.19.0"
+    "@sentry/core" "11.0.0-alpha.1"
+    "@sentry/opentelemetry" "11.0.0-alpha.1"
+    "@sentry/server-utils" "11.0.0-alpha.1"
 
-"@sentry/opentelemetry@11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-11.0.0-alpha.0.tgz#26a68b597969f813529002ee913c6bfdfdb4f9e1"
-  integrity sha512-4oS/ChVuluW6AaF9mSe00diNc8mDiRfjtSKbzOALrL2HRXf00fNUr/zOi1KgiLm6E96CMXL5P1rpEo+dJ/qVFw==
+"@sentry/opentelemetry@11.0.0-alpha.1":
+  version "11.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-11.0.0-alpha.1.tgz#9a162ceaa4917a0e2a56623b8a6b44ad30228327"
+  integrity sha512-JH8oH85SCFgecEyncOIQ2mzvgQnVUrdsEc1BR2nLT3AymwyhT6fblbMp2B8IiuEwBC+YHLf631KCYoVfrLj85Q==
   dependencies:
-    "@sentry/conventions" "^0.16.0"
-    "@sentry/core" "11.0.0-alpha.0"
+    "@sentry/conventions" "^0.19.0"
+    "@sentry/core" "11.0.0-alpha.1"
 
-"@sentry/profiling-node@11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-11.0.0-alpha.0.tgz#7c9f13660a7be2f2ec303a38454f969af739e293"
-  integrity sha512-mQ6OrYZkBM1YoChhOOLw0pbOA+2pOTXMJAfxJs6On/cpbZtJRZYby+bQUhvyio7g1P+hokMjsm/R2zrcI1fjpQ==
+"@sentry/profiling-node@11.0.0-alpha.1":
+  version "11.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-11.0.0-alpha.1.tgz#0997943299d4cc5612701a105cb7d12b72bf653d"
+  integrity sha512-CfkN2nCE0CbzCpAih3f/B6vFXHK8VKeCHiJCUmKraFg2g4hMrhGqOCCa5cs9vGCmxl8j07wBUybioRGpCcIzBA==
   dependencies:
-    "@sentry/core" "11.0.0-alpha.0"
-    "@sentry/node" "11.0.0-alpha.0"
+    "@sentry/core" "11.0.0-alpha.1"
+    "@sentry/node" "11.0.0-alpha.1"
     "@sentry/node-cpu-profiler" "^2.4.3"
 
-"@sentry/server-utils@11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sentry/server-utils/-/server-utils-11.0.0-alpha.0.tgz#532ecebe7fbc6d36e4c860ae46fa4c2f77d6b858"
-  integrity sha512-fhyka8mkJWEP0yCnIkBccNZHpytx1+JY2nnbfIeLy+298zhFozOtddi4wqQedZP9y1RuAl6qHY3efbwE/9IPLQ==
+"@sentry/server-utils@11.0.0-alpha.1":
+  version "11.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sentry/server-utils/-/server-utils-11.0.0-alpha.1.tgz#0e22c9cda63e841a309b0e0e763498af78d675a1"
+  integrity sha512-/xuTDeCCmkyfIYx+7UuKv9OKanZj4h0wibZ8b/gR7ElivcOSPUEY+YDlr/tojwoJoI8c4nEdcgjVH1Rb7S18uA==
   dependencies:
     "@opentelemetry/api" "^1.9.1"
-    "@sentry/conventions" "^0.16.0"
-    "@sentry/core" "11.0.0-alpha.0"
+    "@sentry/conventions" "^0.19.0"
+    "@sentry/core" "11.0.0-alpha.1"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
## What

Update `@sentry/node` and `@sentry/profiling-node` to `11.0.0-alpha.1`.

## Why

Keep tracking the v11 alpha line before the stable release.