### PR TITLE
chore(gocd): use GitHub App credentials

### DIFF
--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-checks-githubactions-checkruns \
+checks-githubactions-checkruns2 \
   "getsentry/chartcuterie" \
   "${GO_REVISION_CHARTCUTERIE_REPO}" \
   "build"

--- a/gocd/templates/pipelines/chartcuterie.libsonnet
+++ b/gocd/templates/pipelines/chartcuterie.libsonnet
@@ -48,7 +48,8 @@ function(region) {
             timeout: 1200,
             elastic_profile_id: 'chartcuterie',
             environment_variables: {
-              GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+              GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+              GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
             },
             tasks: [
               gocdtasks.script(importstr '../bash/check-github-runs.sh'),


### PR DESCRIPTION
Replace GoCD GitHub token references with GitHub App credentials.

- Pass GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to GoCD jobs.
- Preserve legacy runtime compatibility where the existing helper supports it.