### PR TITLE
chore: Update @sentry/node to 11.0.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "README"
   ],
   "dependencies": {
-    "@sentry/node": "11.0.0-alpha.1",
-    "@sentry/profiling-node": "11.0.0-alpha.1",
+    "@sentry/node": "11.0.0-alpha.2",
+    "@sentry/profiling-node": "11.0.0-alpha.2",
     "canvas": "^3.2.0",
     "dotenv": "^8.2.0",
     "echarts": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,91 +911,31 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sentry/bundler-plugins@11.0.0-alpha.1":
-  version "11.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.1.tgz#829f8d9343fe9c8bcd0286e575f98b6868a120d4"
-  integrity sha512-vFYrP4a2tKPkkFmuxg2c45XqhNnn07olYwP7blFLqD4QMd7blfvB0WnC0xpmke4CUYMl+ELhWbt8KgfyiV/qLg==
+"@sentry/bundler-plugins@11.0.0-alpha.2":
+  version "11.0.0-alpha.2"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/bundler-plugins/-/bundler-plugins-11.0.0-alpha.2.tgz#a168374bfd39dce2946c698733c378ea86f810e9"
+  integrity sha512-cWTtt94lsNmZTGo8Rr0IDilfc4wuuaDnEvhoZqvuo2RJixMtwr3Erq9S1nbiX4jnP2fcLNnZm8nc/R4BbLIHrg==
   dependencies:
     "@babel/core" "^7.18.5"
-    "@sentry/cli" "^2.58.6"
-    "@sentry/core" "11.0.0-alpha.1"
+    "@sentry/core" "11.0.0-alpha.2"
     dotenv "^17.4.2"
     find-up "^5.0.0"
     glob "^13.0.6"
     magic-string "~0.30.8"
+    sentry "^0.44.0"
     supports-color "^8.1.1"
 
-"@sentry/cli-darwin@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz#38fd82751014b287e58e99ef948d01ca1e09f41d"
-  integrity sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==
+"@sentry/conventions@^0.20.0":
+  version "0.20.0"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.20.0.tgz#f73f6f46934d754dacef447755b5adf1bf7f3245"
+  integrity sha512-nAL3tL+xgom6Dbuxq0NCEZZfBNIrUspjDJRcMMRl3WLiBCSeZzNCa7an48IpnrZoVMpAi2NQ2v9rFU+EQziKuQ==
 
-"@sentry/cli-linux-arm64@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz#6e660e457af7928c1be8191c77646801fe3fa6a0"
-  integrity sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==
-
-"@sentry/cli-linux-arm@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz#41256912d636193d2a67985b6c9b3efbbe6a47c9"
-  integrity sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==
-
-"@sentry/cli-linux-i686@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz#278e7696d82e51dfbfd7d82ec125dda65d249a43"
-  integrity sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==
-
-"@sentry/cli-linux-x64@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz#57860d46ac3397c33bbcc6224ac19b7de2502c18"
-  integrity sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==
-
-"@sentry/cli-win32-arm64@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz#9335a5d2411381dca1d6b11fdd71a4342b375fc3"
-  integrity sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==
-
-"@sentry/cli-win32-i686@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz#2afd19536ef111af43538ccc5f9c8c0b179d930e"
-  integrity sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==
-
-"@sentry/cli-win32-x64@2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz#8d0e70b5660cc82a7763a4bbe9346cf18e49e07e"
-  integrity sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==
-
-"@sentry/cli@^2.58.6":
-  version "2.58.6"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.58.6.tgz#72edb4977d822757511b279e006b00f139e24945"
-  integrity sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==
+"@sentry/core@11.0.0-alpha.2":
+  version "11.0.0-alpha.2"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/core/-/core-11.0.0-alpha.2.tgz#440abc10884dfbb9f70506ddcf39b7d05b570c42"
+  integrity sha512-GvqlS+z2UxCy92nrH0PMYn/Xw5Tw40VNGkJ85G/C7S55O/NO3c8vU+oJG9/exCKgs/N+u7fSKYgPubuvaArkLQ==
   dependencies:
-    https-proxy-agent "^5.0.0"
-    node-fetch "^2.6.7"
-    progress "^2.0.3"
-    proxy-from-env "^1.1.0"
-    which "^2.0.2"
-  optionalDependencies:
-    "@sentry/cli-darwin" "2.58.6"
-    "@sentry/cli-linux-arm" "2.58.6"
-    "@sentry/cli-linux-arm64" "2.58.6"
-    "@sentry/cli-linux-i686" "2.58.6"
-    "@sentry/cli-linux-x64" "2.58.6"
-    "@sentry/cli-win32-arm64" "2.58.6"
-    "@sentry/cli-win32-i686" "2.58.6"
-    "@sentry/cli-win32-x64" "2.58.6"
-
-"@sentry/conventions@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.19.0.tgz#da81dd1b8c4f2f42aca2d74251a07ff9f8718e42"
-  integrity sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==
-
-"@sentry/core@11.0.0-alpha.1":
-  version "11.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-11.0.0-alpha.1.tgz#8a7eaec19a33088e6658f0f49b1a076a5271b1d3"
-  integrity sha512-KIiN6A7QltDlPZ+OJAOfDpzfxGBUsubJoLOKV1T1pj/9KWdfQlb6V0iCPPON+SwqHTWC8YifdenmC0J5jq5BCA==
-  dependencies:
-    "@sentry/conventions" "^0.19.0"
+    "@sentry/conventions" "^0.20.0"
 
 "@sentry/node-cpu-profiler@^2.4.3":
   version "2.4.3"
@@ -1005,43 +945,43 @@
     detect-libc "^2.0.3"
     node-abi "^3.73.0"
 
-"@sentry/node@11.0.0-alpha.1":
-  version "11.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-11.0.0-alpha.1.tgz#b77ed12fac04828338ed7ed422420a795765d30a"
-  integrity sha512-fJYi66rT5WfRfRQkIqchwj5hGobhcEJw6MGfTq3dR4xh9Ksk+hLADz+U4zu53ZuV0NXnGTHbOLWzlJ8J+zjhKA==
+"@sentry/node@11.0.0-alpha.2":
+  version "11.0.0-alpha.2"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/node/-/node-11.0.0-alpha.2.tgz#e382f62487089a702ff2b5437bce53775440d674"
+  integrity sha512-RDlLF3gUsiRD63V8NdkAk2mAbKqkib4qhsErOargPJ9rrNKXtslq/DgUIM1Aa8SoxduyO2H2U5hbWf/twlShzA==
   dependencies:
     "@opentelemetry/api" "^1.9.1"
-    "@sentry/bundler-plugins" "11.0.0-alpha.1"
-    "@sentry/conventions" "^0.19.0"
-    "@sentry/core" "11.0.0-alpha.1"
-    "@sentry/opentelemetry" "11.0.0-alpha.1"
-    "@sentry/server-utils" "11.0.0-alpha.1"
+    "@sentry/bundler-plugins" "11.0.0-alpha.2"
+    "@sentry/conventions" "^0.20.0"
+    "@sentry/core" "11.0.0-alpha.2"
+    "@sentry/opentelemetry" "11.0.0-alpha.2"
+    "@sentry/server-utils" "11.0.0-alpha.2"
 
-"@sentry/opentelemetry@11.0.0-alpha.1":
-  version "11.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-11.0.0-alpha.1.tgz#9a162ceaa4917a0e2a56623b8a6b44ad30228327"
-  integrity sha512-JH8oH85SCFgecEyncOIQ2mzvgQnVUrdsEc1BR2nLT3AymwyhT6fblbMp2B8IiuEwBC+YHLf631KCYoVfrLj85Q==
+"@sentry/opentelemetry@11.0.0-alpha.2":
+  version "11.0.0-alpha.2"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/opentelemetry/-/opentelemetry-11.0.0-alpha.2.tgz#c5a2179556331317556f0b31f0ef0999ba59c78a"
+  integrity sha512-dojGEVXP48Qcjy+lnqmgmph7y1EHjbdUy3Oq6PT4Wqc1kAdIAaA+KN84g9A1hB6zc6auDx+hgUdhgGyPITzYOA==
   dependencies:
-    "@sentry/conventions" "^0.19.0"
-    "@sentry/core" "11.0.0-alpha.1"
+    "@sentry/conventions" "^0.20.0"
+    "@sentry/core" "11.0.0-alpha.2"
 
-"@sentry/profiling-node@11.0.0-alpha.1":
-  version "11.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sentry/profiling-node/-/profiling-node-11.0.0-alpha.1.tgz#0997943299d4cc5612701a105cb7d12b72bf653d"
-  integrity sha512-CfkN2nCE0CbzCpAih3f/B6vFXHK8VKeCHiJCUmKraFg2g4hMrhGqOCCa5cs9vGCmxl8j07wBUybioRGpCcIzBA==
+"@sentry/profiling-node@11.0.0-alpha.2":
+  version "11.0.0-alpha.2"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/profiling-node/-/profiling-node-11.0.0-alpha.2.tgz#e5e22140f9c528c35d21604ecb01d24ccaea792b"
+  integrity sha512-EkZBu6uQS3qllvaO+Jg2/arTV+T7dHLg4JInIRxq4Ttv+MvA+OaJhVm/yZO82fMJh/dHaUvif1sr+1ZpQkyIWw==
   dependencies:
-    "@sentry/core" "11.0.0-alpha.1"
-    "@sentry/node" "11.0.0-alpha.1"
+    "@sentry/core" "11.0.0-alpha.2"
+    "@sentry/node" "11.0.0-alpha.2"
     "@sentry/node-cpu-profiler" "^2.4.3"
 
-"@sentry/server-utils@11.0.0-alpha.1":
-  version "11.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sentry/server-utils/-/server-utils-11.0.0-alpha.1.tgz#0e22c9cda63e841a309b0e0e763498af78d675a1"
-  integrity sha512-/xuTDeCCmkyfIYx+7UuKv9OKanZj4h0wibZ8b/gR7ElivcOSPUEY+YDlr/tojwoJoI8c4nEdcgjVH1Rb7S18uA==
+"@sentry/server-utils@11.0.0-alpha.2":
+  version "11.0.0-alpha.2"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/server-utils/-/server-utils-11.0.0-alpha.2.tgz#142d371284ffb0237fe4566b34da9594bce8b947"
+  integrity sha512-qJjK1IjWXXoK7rkziPPwa+DvA+FkLGPNVt4jWxw4EjNXEdQSTxamC3LjlQXRpwtsAAfE0623FkZMZesNWJTv4w==
   dependencies:
     "@opentelemetry/api" "^1.9.1"
-    "@sentry/conventions" "^0.19.0"
-    "@sentry/core" "11.0.0-alpha.1"
+    "@sentry/conventions" "^0.20.0"
+    "@sentry/core" "11.0.0-alpha.2"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -1636,13 +1576,6 @@ acorn@^8.9.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
-
-agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
 
 ajv@^6.12.4:
   version "6.14.0"
@@ -2339,13 +2272,6 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-debug@4, debug@^4.3.1, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
@@ -2357,6 +2283,13 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  dependencies:
+    ms "^2.1.3"
+
+debug@^4.3.1, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -3625,14 +3558,6 @@ http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
     statuses "~2.0.2"
     toidentifier "~1.0.1"
 
-https-proxy-agent@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
-  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
-  dependencies:
-    agent-base "6"
-    debug "4"
-
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
@@ -4857,13 +4782,6 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.7:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
@@ -5202,11 +5120,6 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-progress@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
 promise-polyfill@^8.1.3:
   version "8.2.3"
   resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz"
@@ -5236,11 +5149,6 @@ proxy-addr@^2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 ps-tree@^1.2.0:
   version "1.2.0"
@@ -5552,6 +5460,11 @@ send@^1.1.0, send@^1.2.0:
     on-finished "^2.4.1"
     range-parser "^1.2.1"
     statuses "^2.0.2"
+
+sentry@^0.44.0:
+  version "0.44.1"
+  resolved "https://sfw.security.sentry.io/npm/sentry/-/sentry-0.44.1.tgz#d3747b3087e125766c8e939638fae024ee95c972"
+  integrity sha512-LK+RJ2PFsJKM+P0D/zYC+M5gFB1ytfVONU9DVUqJu67YFlwnj3wGJkUzBhCS8R4iUqRdRTAYbFbRKTAe03rW/Q==
 
 serve-static@^2.2.0:
   version "2.2.1"
@@ -6450,7 +6363,7 @@ which-typed-array@^1.1.16, which-typed-array@^1.1.19:
     gopd "^1.2.0"
     has-tostringtag "^1.0.2"
 
-which@^2.0.1, which@^2.0.2:
+which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
## What

Update `@sentry/node` and `@sentry/profiling-node` to 11.0.0-alpha.2.

## Why

Keep chartcuterie on the latest v11 alpha so we catch breaking changes early.